### PR TITLE
Implemented the missing NULL value type

### DIFF
--- a/src/exceptions/ReturnException.php
+++ b/src/exceptions/ReturnException.php
@@ -2,6 +2,8 @@
 
 namespace Smuuf\Primi;
 
+use \Smuuf\Primi\Structures\NullValue;
+
 class ReturnException extends InternalException {
 
 	/** @var mixed **/
@@ -13,7 +15,7 @@ class ReturnException extends InternalException {
 	}
 
 	public function getValue() {
-		return $this->value;
+		return $this->value ?? new NullValue;
 	}
 
 }

--- a/src/handlers/Addition.php
+++ b/src/handlers/Addition.php
@@ -21,26 +21,24 @@ class Addition extends \Smuuf\Primi\StrictObject implements IHandler, IReducer {
 		// Make sure even a single operand can be processed via foreach.
 		Helpers::ensureIndexed($node['ops']);
 
-		// Go through each of the operands and continuously calculate the result value combining the operand's
-		// value with the result-so-far. The operator determining the operands's effect on the result has always
-		// the "n-1" index.
-		$first = \true;
-		$result = \null;
-		foreach ($node['operands'] as $index => $operandNode) {
+		$operands = $node['operands'];
+
+		$firstOperand = array_shift($operands);
+		$handler = HandlerFactory::get($firstOperand['name']);
+		$result = $handler::handle($firstOperand, $context);
+
+		// Go through each of the operands and continuously calculate the result
+		// value combining the operand's value with the result-so-far. The
+		// operator determining the operands's effect on the result has always
+		// the "n" index. (It would be "n-1" but we shifted the first operand
+		// already.)
+		foreach ($operands as $index => $operandNode) {
 
 			$handler = HandlerFactory::get($operandNode['name']);
-
-			// Get the first, initial result.
-			if ($first) {
-				$result = $handler::handle($operandNode, $context);
-				$first = \false;
-				continue;
-			} else {
-				$tmp = $handler::handle($operandNode, $context);
-			}
+			$tmp = $handler::handle($operandNode, $context);
 
 			// Extract the text of the assigned operator node.
-			$op = $node['ops'][$index - 1]['text'];
+			$op = $node['ops'][$index]['text'];
 
 			try {
 

--- a/src/handlers/AnonymousFunction.php
+++ b/src/handlers/AnonymousFunction.php
@@ -28,9 +28,6 @@ class AnonymousFunction extends \Smuuf\Primi\StrictObject implements IHandler {
 
 		}
 
-		// Build convenient hash to ease identification amongst other functions.
-		$name = substr(Helpers::hash($argumentList, $node['body']), 0, 16);
-
 		$fn = FunctionContainer::build($node['body'], $argumentList, $context);
 		return new FuncValue($fn);
 

--- a/src/handlers/ArgumentList.php
+++ b/src/handlers/ArgumentList.php
@@ -17,17 +17,16 @@ class ArgumentList extends \Smuuf\Primi\StrictObject implements IHandler {
 
 	public static function handle(array $node, Context $context) {
 
+		if (!isset($node['args'])) {
+			return [];
+		}
+
 		$list = [];
+		Helpers::ensureIndexed($node['args']);
 
-		if (isset($node['args'])) {
-
-			Helpers::ensureIndexed($node['args']);
-
-			foreach ($node['args'] as $a) {
-				$handler = HandlerFactory::get($a['name']);
-				$list[] = $handler::handle($a, $context);
-			}
-
+		foreach ($node['args'] as $a) {
+			$handler = HandlerFactory::get($a['name']);
+			$list[] = $handler::handle($a, $context);
 		}
 
 		return $list;

--- a/src/handlers/ArrayDefinition.php
+++ b/src/handlers/ArrayDefinition.php
@@ -12,16 +12,21 @@ class ArrayDefinition extends \Smuuf\Primi\StrictObject implements IHandler {
 
 	public static function handle(array $node, Context $context) {
 
-		if (!isset($node['items'])) {
+		if (empty($node['items'])) {
 			return new ArrayValue([]);
 		}
 
-		$result = [];
-		$indexCounter = 0;
-
 		Helpers::ensureIndexed($node['items']);
+		return new ArrayValue(self::buildArray($node['items'], $context));
 
-		foreach ($node['items'] as $itemNode) {
+	}
+
+	protected static function buildArray(array $itemNodes, Context $context): array {
+
+		$result = [];
+		$index = 0;
+
+		foreach ($itemNodes as $itemNode) {
 
 			// Key doesn't have to be defined.
 			if (isset($itemNode['key'])) {
@@ -33,13 +38,13 @@ class ArrayDefinition extends \Smuuf\Primi\StrictObject implements IHandler {
 				// And if it is a numeric integer, use it as a base for the index counter
 				// we would have used if the key was not provided.
 				if (NumberValue::isNumericInt($key)) {
-					$indexCounter = $key + 1;
+					$index = $key + 1;
 				}
 
 			} else {
 
 				// The key was not provided, assign a key for this item using our internal index counter.
-				$key = $indexCounter++;
+				$key = $index++;
 
 			}
 
@@ -50,7 +55,7 @@ class ArrayDefinition extends \Smuuf\Primi\StrictObject implements IHandler {
 
 		}
 
-		return new ArrayValue($result);
+		return $result;
 
 	}
 

--- a/src/handlers/Assignment.php
+++ b/src/handlers/Assignment.php
@@ -33,7 +33,7 @@ class Assignment extends \Smuuf\Primi\StrictObject implements IHandler {
 			break;
 		}
 
-		// Assignment also returns its value.
+		// An assignment also returns its value.
 		return $return;
 
 	}

--- a/src/handlers/Multiplication.php
+++ b/src/handlers/Multiplication.php
@@ -20,23 +20,24 @@ class Multiplication extends \Smuuf\Primi\StrictObject implements IHandler, IRed
 
 		Helpers::ensureIndexed($node['ops']);
 
-		// Go through each of the operands and build the final result value combining the operand's value with the
-		// so-far-result. The operator determining the operands's effect on the result always has the "n-1" index.
-		$first = \true;
-		$result = \null;
-		foreach ($node['operands'] as $index => $operandNode) {
+		$operands = $node['operands'];
+
+		$firstOperand = array_shift($operands);
+		$handler = HandlerFactory::get($firstOperand['name']);
+		$result = $handler::handle($firstOperand, $context);
+
+		// Go through each of the operands and continuously calculate the result
+		// value combining the operand's value with the result-so-far. The
+		// operator determining the operands's effect on the result has always
+		// the "n" index. (It would be "n-1" but we shifted the first operand
+		// already.)
+		foreach ($operands as $index => $operandNode) {
 
 			$handler = HandlerFactory::get($operandNode['name']);
-			if ($first) {
-				$result = $handler::handle($operandNode, $context);
-				$first = \false;
-				continue;
-			} else {
-				$tmp = $handler::handle($operandNode, $context);
-			}
+			$tmp = $handler::handle($operandNode, $context);
 
 			// Extract the text of the assigned operator node.
-			$op = $node['ops'][$index - 1]['text'];
+			$op = $node['ops'][$index]['text'];
 
 			try {
 

--- a/src/handlers/NullLiteral.php
+++ b/src/handlers/NullLiteral.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Smuuf\Primi\Handlers;
+
+use \Smuuf\Primi\Structures\NullValue;
+use \Smuuf\Primi\Context;
+
+class NullLiteral extends \Smuuf\Primi\StrictObject implements IHandler {
+
+	public static function handle(array $node, Context $context) {
+		return new NullValue;
+	}
+
+}

--- a/src/parser/CompiledParser.php
+++ b/src/parser/CompiledParser.php
@@ -66,97 +66,127 @@ function match_BoolLiteral ($stack = []) {
 }
 
 
+/* NullLiteral: "null" */
+protected $match_NullLiteral_typestack = array('NullLiteral');
+function match_NullLiteral ($stack = []) {
+	$matchrule = "NullLiteral"; $result = $this->construct($matchrule, $matchrule, \null);
+	if (( $subres = $this->literal( 'null' ) ) !== \false) {
+		$result["text"] .= $subres;
+		return $this->finalise($result);
+	}
+	else { return \false; }
+}
+
+
 /* RegexLiteral: "/" /(\\\/|[^\/])+/ "/" */
 protected $match_RegexLiteral_typestack = array('RegexLiteral');
 function match_RegexLiteral ($stack = []) {
 	$matchrule = "RegexLiteral"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_10 = \null;
+	$_11 = \null;
 	do {
 		if (\substr($this->string,$this->pos,1) === '/') {
 			$this->pos += 1;
 			$result["text"] .= '/';
 		}
-		else { $_10 = \false; break; }
+		else { $_11 = \false; break; }
 		if (( $subres = $this->rx( '/(\\\\\/|[^\/])+/' ) ) !== \false) { $result["text"] .= $subres; }
-		else { $_10 = \false; break; }
+		else { $_11 = \false; break; }
 		if (\substr($this->string,$this->pos,1) === '/') {
 			$this->pos += 1;
 			$result["text"] .= '/';
 		}
-		else { $_10 = \false; break; }
-		$_10 = \true; break;
+		else { $_11 = \false; break; }
+		$_11 = \true; break;
 	}
 	while(0);
-	if( $_10 === \true ) { return $this->finalise($result); }
-	if( $_10 === \false) { return \false; }
+	if( $_11 === \true ) { return $this->finalise($result); }
+	if( $_11 === \false) { return \false; }
 }
 
 
-/* Literal: skip:NumberLiteral | skip:StringLiteral | skip:BoolLiteral | skip:RegexLiteral */
+/* Literal: skip:NumberLiteral | skip:StringLiteral | skip:BoolLiteral | skip:NullLiteral | skip:RegexLiteral */
 protected $match_Literal_typestack = array('Literal');
 function match_Literal ($stack = []) {
 	$matchrule = "Literal"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_23 = \null;
+	$_28 = \null;
 	do {
-		$res_12 = $result;
-		$pos_12 = $this->pos;
+		$res_13 = $result;
+		$pos_13 = $this->pos;
 		$matcher = 'match_'.'NumberLiteral'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) {
 			$this->store( $result, $subres, "skip" );
-			$_23 = \true; break;
+			$_28 = \true; break;
 		}
-		$result = $res_12;
-		$this->pos = $pos_12;
-		$_21 = \null;
+		$result = $res_13;
+		$this->pos = $pos_13;
+		$_26 = \null;
 		do {
-			$res_14 = $result;
-			$pos_14 = $this->pos;
+			$res_15 = $result;
+			$pos_15 = $this->pos;
 			$matcher = 'match_'.'StringLiteral'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 			if ($subres !== \false) {
 				$this->store( $result, $subres, "skip" );
-				$_21 = \true; break;
+				$_26 = \true; break;
 			}
-			$result = $res_14;
-			$this->pos = $pos_14;
-			$_19 = \null;
+			$result = $res_15;
+			$this->pos = $pos_15;
+			$_24 = \null;
 			do {
-				$res_16 = $result;
-				$pos_16 = $this->pos;
+				$res_17 = $result;
+				$pos_17 = $this->pos;
 				$matcher = 'match_'.'BoolLiteral'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 				if ($subres !== \false) {
 					$this->store( $result, $subres, "skip" );
-					$_19 = \true; break;
+					$_24 = \true; break;
 				}
-				$result = $res_16;
-				$this->pos = $pos_16;
-				$matcher = 'match_'.'RegexLiteral'; $key = $matcher; $pos = $this->pos;
-				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
-				if ($subres !== \false) {
-					$this->store( $result, $subres, "skip" );
-					$_19 = \true; break;
+				$result = $res_17;
+				$this->pos = $pos_17;
+				$_22 = \null;
+				do {
+					$res_19 = $result;
+					$pos_19 = $this->pos;
+					$matcher = 'match_'.'NullLiteral'; $key = $matcher; $pos = $this->pos;
+					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
+					if ($subres !== \false) {
+						$this->store( $result, $subres, "skip" );
+						$_22 = \true; break;
+					}
+					$result = $res_19;
+					$this->pos = $pos_19;
+					$matcher = 'match_'.'RegexLiteral'; $key = $matcher; $pos = $this->pos;
+					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
+					if ($subres !== \false) {
+						$this->store( $result, $subres, "skip" );
+						$_22 = \true; break;
+					}
+					$result = $res_19;
+					$this->pos = $pos_19;
+					$_22 = \false; break;
 				}
-				$result = $res_16;
-				$this->pos = $pos_16;
-				$_19 = \false; break;
+				while(0);
+				if( $_22 === \true ) { $_24 = \true; break; }
+				$result = $res_17;
+				$this->pos = $pos_17;
+				$_24 = \false; break;
 			}
 			while(0);
-			if( $_19 === \true ) { $_21 = \true; break; }
-			$result = $res_14;
-			$this->pos = $pos_14;
-			$_21 = \false; break;
+			if( $_24 === \true ) { $_26 = \true; break; }
+			$result = $res_15;
+			$this->pos = $pos_15;
+			$_26 = \false; break;
 		}
 		while(0);
-		if( $_21 === \true ) { $_23 = \true; break; }
-		$result = $res_12;
-		$this->pos = $pos_12;
-		$_23 = \false; break;
+		if( $_26 === \true ) { $_28 = \true; break; }
+		$result = $res_13;
+		$this->pos = $pos_13;
+		$_28 = \false; break;
 	}
 	while(0);
-	if( $_23 === \true ) { return $this->finalise($result); }
-	if( $_23 === \false) { return \false; }
+	if( $_28 === \true ) { return $this->finalise($result); }
+	if( $_28 === \false) { return \false; }
 }
 
 
@@ -176,69 +206,69 @@ function match_VariableName ($stack = []) {
 protected $match_Variable_typestack = array('Variable');
 function match_Variable ($stack = []) {
 	$matchrule = "Variable"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_35 = \null;
+	$_40 = \null;
 	do {
-		$res_26 = $result;
-		$pos_26 = $this->pos;
-		$_29 = \null;
+		$res_31 = $result;
+		$pos_31 = $this->pos;
+		$_34 = \null;
 		do {
 			$matcher = 'match_'.'VariableName'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 			if ($subres !== \false) {
 				$this->store( $result, $subres, "core" );
 			}
-			else { $_29 = \false; break; }
-			$res_28 = $result;
-			$pos_28 = $this->pos;
+			else { $_34 = \false; break; }
+			$res_33 = $result;
+			$pos_33 = $this->pos;
 			$matcher = 'match_'.'UnaryOperator'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 			if ($subres !== \false) {
 				$this->store( $result, $subres, "post" );
 			}
 			else {
-				$result = $res_28;
-				$this->pos = $pos_28;
-				unset( $res_28 );
-				unset( $pos_28 );
+				$result = $res_33;
+				$this->pos = $pos_33;
+				unset( $res_33 );
+				unset( $pos_33 );
 			}
-			$_29 = \true; break;
+			$_34 = \true; break;
 		}
 		while(0);
-		if( $_29 === \true ) { $_35 = \true; break; }
-		$result = $res_26;
-		$this->pos = $pos_26;
-		$_33 = \null;
+		if( $_34 === \true ) { $_40 = \true; break; }
+		$result = $res_31;
+		$this->pos = $pos_31;
+		$_38 = \null;
 		do {
-			$res_31 = $result;
-			$pos_31 = $this->pos;
+			$res_36 = $result;
+			$pos_36 = $this->pos;
 			$matcher = 'match_'.'UnaryOperator'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 			if ($subres !== \false) {
 				$this->store( $result, $subres, "pre" );
 			}
 			else {
-				$result = $res_31;
-				$this->pos = $pos_31;
-				unset( $res_31 );
-				unset( $pos_31 );
+				$result = $res_36;
+				$this->pos = $pos_36;
+				unset( $res_36 );
+				unset( $pos_36 );
 			}
 			$matcher = 'match_'.'VariableName'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 			if ($subres !== \false) {
 				$this->store( $result, $subres, "core" );
 			}
-			else { $_33 = \false; break; }
-			$_33 = \true; break;
+			else { $_38 = \false; break; }
+			$_38 = \true; break;
 		}
 		while(0);
-		if( $_33 === \true ) { $_35 = \true; break; }
-		$result = $res_26;
-		$this->pos = $pos_26;
-		$_35 = \false; break;
+		if( $_38 === \true ) { $_40 = \true; break; }
+		$result = $res_31;
+		$this->pos = $pos_31;
+		$_40 = \false; break;
 	}
 	while(0);
-	if( $_35 === \true ) { return $this->finalise($result); }
-	if( $_35 === \false) { return \false; }
+	if( $_40 === \true ) { return $this->finalise($result); }
+	if( $_40 === \false) { return \false; }
 }
 
 
@@ -260,125 +290,125 @@ function match_PropertyGetter ($stack = []) {
 protected $match_AnonymousFunction_typestack = array('AnonymousFunction');
 function match_AnonymousFunction ($stack = []) {
 	$matchrule = "AnonymousFunction"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_61 = \null;
+	$_66 = \null;
 	do {
-		$res_38 = $result;
-		$pos_38 = $this->pos;
-		$_48 = \null;
+		$res_43 = $result;
+		$pos_43 = $this->pos;
+		$_53 = \null;
 		do {
 			if (( $subres = $this->literal( 'function' ) ) !== \false) { $result["text"] .= $subres; }
-			else { $_48 = \false; break; }
+			else { $_53 = \false; break; }
 			$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 			if ($subres !== \false) { $this->store( $result, $subres ); }
-			else { $_48 = \false; break; }
+			else { $_53 = \false; break; }
 			if (\substr($this->string,$this->pos,1) === '(') {
 				$this->pos += 1;
 				$result["text"] .= '(';
 			}
-			else { $_48 = \false; break; }
+			else { $_53 = \false; break; }
 			$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 			if ($subres !== \false) { $this->store( $result, $subres ); }
-			else { $_48 = \false; break; }
-			$res_43 = $result;
-			$pos_43 = $this->pos;
+			else { $_53 = \false; break; }
+			$res_48 = $result;
+			$pos_48 = $this->pos;
 			$matcher = 'match_'.'FunctionDefinitionArgumentList'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 			if ($subres !== \false) {
 				$this->store( $result, $subres, "args" );
 			}
 			else {
-				$result = $res_43;
-				$this->pos = $pos_43;
-				unset( $res_43 );
-				unset( $pos_43 );
+				$result = $res_48;
+				$this->pos = $pos_48;
+				unset( $res_48 );
+				unset( $pos_48 );
 			}
 			$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 			if ($subres !== \false) { $this->store( $result, $subres ); }
-			else { $_48 = \false; break; }
+			else { $_53 = \false; break; }
 			if (\substr($this->string,$this->pos,1) === ')') {
 				$this->pos += 1;
 				$result["text"] .= ')';
 			}
-			else { $_48 = \false; break; }
+			else { $_53 = \false; break; }
 			$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 			if ($subres !== \false) { $this->store( $result, $subres ); }
-			else { $_48 = \false; break; }
+			else { $_53 = \false; break; }
 			$matcher = 'match_'.'Block'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 			if ($subres !== \false) {
 				$this->store( $result, $subres, "body" );
 			}
-			else { $_48 = \false; break; }
-			$_48 = \true; break;
+			else { $_53 = \false; break; }
+			$_53 = \true; break;
 		}
 		while(0);
-		if( $_48 === \true ) { $_61 = \true; break; }
-		$result = $res_38;
-		$this->pos = $pos_38;
-		$_59 = \null;
+		if( $_53 === \true ) { $_66 = \true; break; }
+		$result = $res_43;
+		$this->pos = $pos_43;
+		$_64 = \null;
 		do {
 			if (\substr($this->string,$this->pos,1) === '(') {
 				$this->pos += 1;
 				$result["text"] .= '(';
 			}
-			else { $_59 = \false; break; }
+			else { $_64 = \false; break; }
 			$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 			if ($subres !== \false) { $this->store( $result, $subres ); }
-			else { $_59 = \false; break; }
-			$res_52 = $result;
-			$pos_52 = $this->pos;
+			else { $_64 = \false; break; }
+			$res_57 = $result;
+			$pos_57 = $this->pos;
 			$matcher = 'match_'.'FunctionDefinitionArgumentList'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 			if ($subres !== \false) {
 				$this->store( $result, $subres, "args" );
 			}
 			else {
-				$result = $res_52;
-				$this->pos = $pos_52;
-				unset( $res_52 );
-				unset( $pos_52 );
+				$result = $res_57;
+				$this->pos = $pos_57;
+				unset( $res_57 );
+				unset( $pos_57 );
 			}
 			$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 			if ($subres !== \false) { $this->store( $result, $subres ); }
-			else { $_59 = \false; break; }
+			else { $_64 = \false; break; }
 			if (\substr($this->string,$this->pos,1) === ')') {
 				$this->pos += 1;
 				$result["text"] .= ')';
 			}
-			else { $_59 = \false; break; }
+			else { $_64 = \false; break; }
 			$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 			if ($subres !== \false) { $this->store( $result, $subres ); }
-			else { $_59 = \false; break; }
+			else { $_64 = \false; break; }
 			if (( $subres = $this->literal( '=>' ) ) !== \false) { $result["text"] .= $subres; }
-			else { $_59 = \false; break; }
+			else { $_64 = \false; break; }
 			$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 			if ($subres !== \false) { $this->store( $result, $subres ); }
-			else { $_59 = \false; break; }
+			else { $_64 = \false; break; }
 			$matcher = 'match_'.'Block'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 			if ($subres !== \false) {
 				$this->store( $result, $subres, "body" );
 			}
-			else { $_59 = \false; break; }
-			$_59 = \true; break;
+			else { $_64 = \false; break; }
+			$_64 = \true; break;
 		}
 		while(0);
-		if( $_59 === \true ) { $_61 = \true; break; }
-		$result = $res_38;
-		$this->pos = $pos_38;
-		$_61 = \false; break;
+		if( $_64 === \true ) { $_66 = \true; break; }
+		$result = $res_43;
+		$this->pos = $pos_43;
+		$_66 = \false; break;
 	}
 	while(0);
-	if( $_61 === \true ) { return $this->finalise($result); }
-	if( $_61 === \false) { return \false; }
+	if( $_66 === \true ) { return $this->finalise($result); }
+	if( $_66 === \false) { return \false; }
 }
 
 
@@ -386,51 +416,51 @@ function match_AnonymousFunction ($stack = []) {
 protected $match_ArrayItem_typestack = array('ArrayItem');
 function match_ArrayItem ($stack = []) {
 	$matchrule = "ArrayItem"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_70 = \null;
+	$_75 = \null;
 	do {
-		$res_67 = $result;
-		$pos_67 = $this->pos;
-		$_66 = \null;
+		$res_72 = $result;
+		$pos_72 = $this->pos;
+		$_71 = \null;
 		do {
 			$matcher = 'match_'.'Expression'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 			if ($subres !== \false) {
 				$this->store( $result, $subres, "key" );
 			}
-			else { $_66 = \false; break; }
+			else { $_71 = \false; break; }
 			$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 			if ($subres !== \false) { $this->store( $result, $subres ); }
-			else { $_66 = \false; break; }
+			else { $_71 = \false; break; }
 			if (\substr($this->string,$this->pos,1) === ':') {
 				$this->pos += 1;
 				$result["text"] .= ':';
 			}
-			else { $_66 = \false; break; }
-			$_66 = \true; break;
+			else { $_71 = \false; break; }
+			$_71 = \true; break;
 		}
 		while(0);
-		if( $_66 === \false) {
-			$result = $res_67;
-			$this->pos = $pos_67;
-			unset( $res_67 );
-			unset( $pos_67 );
+		if( $_71 === \false) {
+			$result = $res_72;
+			$this->pos = $pos_72;
+			unset( $res_72 );
+			unset( $pos_72 );
 		}
 		$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) { $this->store( $result, $subres ); }
-		else { $_70 = \false; break; }
+		else { $_75 = \false; break; }
 		$matcher = 'match_'.'Expression'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) {
 			$this->store( $result, $subres, "value" );
 		}
-		else { $_70 = \false; break; }
-		$_70 = \true; break;
+		else { $_75 = \false; break; }
+		$_75 = \true; break;
 	}
 	while(0);
-	if( $_70 === \true ) { return $this->finalise($result); }
-	if( $_70 === \false) { return \false; }
+	if( $_75 === \true ) { return $this->finalise($result); }
+	if( $_75 === \false) { return \false; }
 }
 
 
@@ -438,88 +468,62 @@ function match_ArrayItem ($stack = []) {
 protected $match_ArrayDefinition_typestack = array('ArrayDefinition');
 function match_ArrayDefinition ($stack = []) {
 	$matchrule = "ArrayDefinition"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_89 = \null;
+	$_94 = \null;
 	do {
 		if (\substr($this->string,$this->pos,1) === '[') {
 			$this->pos += 1;
 			$result["text"] .= '[';
 		}
-		else { $_89 = \false; break; }
+		else { $_94 = \false; break; }
 		$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) { $this->store( $result, $subres ); }
-		else { $_89 = \false; break; }
-		$res_82 = $result;
-		$pos_82 = $this->pos;
-		$_81 = \null;
+		else { $_94 = \false; break; }
+		$res_87 = $result;
+		$pos_87 = $this->pos;
+		$_86 = \null;
 		do {
 			$matcher = 'match_'.'ArrayItem'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 			if ($subres !== \false) {
 				$this->store( $result, $subres, "items" );
 			}
-			else { $_81 = \false; break; }
+			else { $_86 = \false; break; }
 			while (\true) {
-				$res_80 = $result;
-				$pos_80 = $this->pos;
-				$_79 = \null;
+				$res_85 = $result;
+				$pos_85 = $this->pos;
+				$_84 = \null;
 				do {
 					$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 					if ($subres !== \false) { $this->store( $result, $subres ); }
-					else { $_79 = \false; break; }
+					else { $_84 = \false; break; }
 					if (\substr($this->string,$this->pos,1) === ',') {
 						$this->pos += 1;
 						$result["text"] .= ',';
 					}
-					else { $_79 = \false; break; }
+					else { $_84 = \false; break; }
 					$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 					if ($subres !== \false) { $this->store( $result, $subres ); }
-					else { $_79 = \false; break; }
+					else { $_84 = \false; break; }
 					$matcher = 'match_'.'ArrayItem'; $key = $matcher; $pos = $this->pos;
 					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 					if ($subres !== \false) {
 						$this->store( $result, $subres, "items" );
 					}
-					else { $_79 = \false; break; }
-					$_79 = \true; break;
+					else { $_84 = \false; break; }
+					$_84 = \true; break;
 				}
 				while(0);
-				if( $_79 === \false) {
-					$result = $res_80;
-					$this->pos = $pos_80;
-					unset( $res_80 );
-					unset( $pos_80 );
+				if( $_84 === \false) {
+					$result = $res_85;
+					$this->pos = $pos_85;
+					unset( $res_85 );
+					unset( $pos_85 );
 					break;
 				}
 			}
-			$_81 = \true; break;
-		}
-		while(0);
-		if( $_81 === \false) {
-			$result = $res_82;
-			$this->pos = $pos_82;
-			unset( $res_82 );
-			unset( $pos_82 );
-		}
-		$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
-		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
-		if ($subres !== \false) { $this->store( $result, $subres ); }
-		else { $_89 = \false; break; }
-		$res_87 = $result;
-		$pos_87 = $this->pos;
-		$_86 = \null;
-		do {
-			if (\substr($this->string,$this->pos,1) === ',') {
-				$this->pos += 1;
-				$result["text"] .= ',';
-			}
-			else { $_86 = \false; break; }
-			$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
-			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
-			if ($subres !== \false) { $this->store( $result, $subres ); }
-			else { $_86 = \false; break; }
 			$_86 = \true; break;
 		}
 		while(0);
@@ -529,16 +533,42 @@ function match_ArrayDefinition ($stack = []) {
 			unset( $res_87 );
 			unset( $pos_87 );
 		}
+		$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
+		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
+		if ($subres !== \false) { $this->store( $result, $subres ); }
+		else { $_94 = \false; break; }
+		$res_92 = $result;
+		$pos_92 = $this->pos;
+		$_91 = \null;
+		do {
+			if (\substr($this->string,$this->pos,1) === ',') {
+				$this->pos += 1;
+				$result["text"] .= ',';
+			}
+			else { $_91 = \false; break; }
+			$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
+			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
+			if ($subres !== \false) { $this->store( $result, $subres ); }
+			else { $_91 = \false; break; }
+			$_91 = \true; break;
+		}
+		while(0);
+		if( $_91 === \false) {
+			$result = $res_92;
+			$this->pos = $pos_92;
+			unset( $res_92 );
+			unset( $pos_92 );
+		}
 		if (\substr($this->string,$this->pos,1) === ']') {
 			$this->pos += 1;
 			$result["text"] .= ']';
 		}
-		else { $_89 = \false; break; }
-		$_89 = \true; break;
+		else { $_94 = \false; break; }
+		$_94 = \true; break;
 	}
 	while(0);
-	if( $_89 === \true ) { return $this->finalise($result); }
-	if( $_89 === \false) { return \false; }
+	if( $_94 === \true ) { return $this->finalise($result); }
+	if( $_94 === \false) { return \false; }
 }
 
 
@@ -546,49 +576,49 @@ function match_ArrayDefinition ($stack = []) {
 protected $match_Value_typestack = array('Value');
 function match_Value ($stack = []) {
 	$matchrule = "Value"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_98 = \null;
+	$_103 = \null;
 	do {
-		$res_91 = $result;
-		$pos_91 = $this->pos;
+		$res_96 = $result;
+		$pos_96 = $this->pos;
 		$matcher = 'match_'.'Literal'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) {
 			$this->store( $result, $subres, "skip" );
-			$_98 = \true; break;
+			$_103 = \true; break;
 		}
-		$result = $res_91;
-		$this->pos = $pos_91;
-		$_96 = \null;
+		$result = $res_96;
+		$this->pos = $pos_96;
+		$_101 = \null;
 		do {
-			$res_93 = $result;
-			$pos_93 = $this->pos;
+			$res_98 = $result;
+			$pos_98 = $this->pos;
 			$matcher = 'match_'.'Variable'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 			if ($subres !== \false) {
 				$this->store( $result, $subres, "skip" );
-				$_96 = \true; break;
+				$_101 = \true; break;
 			}
-			$result = $res_93;
-			$this->pos = $pos_93;
+			$result = $res_98;
+			$this->pos = $pos_98;
 			$matcher = 'match_'.'ArrayDefinition'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 			if ($subres !== \false) {
 				$this->store( $result, $subres, "skip" );
-				$_96 = \true; break;
+				$_101 = \true; break;
 			}
-			$result = $res_93;
-			$this->pos = $pos_93;
-			$_96 = \false; break;
+			$result = $res_98;
+			$this->pos = $pos_98;
+			$_101 = \false; break;
 		}
 		while(0);
-		if( $_96 === \true ) { $_98 = \true; break; }
-		$result = $res_91;
-		$this->pos = $pos_91;
-		$_98 = \false; break;
+		if( $_101 === \true ) { $_103 = \true; break; }
+		$result = $res_96;
+		$this->pos = $pos_96;
+		$_103 = \false; break;
 	}
 	while(0);
-	if( $_98 === \true ) { return $this->finalise($result); }
-	if( $_98 === \false) { return \false; }
+	if( $_103 === \true ) { return $this->finalise($result); }
+	if( $_103 === \false) { return \false; }
 }
 
 
@@ -596,59 +626,59 @@ function match_Value ($stack = []) {
 protected $match_DereferencableValue_typestack = array('DereferencableValue');
 function match_DereferencableValue ($stack = []) {
 	$matchrule = "DereferencableValue"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_108 = \null;
+	$_113 = \null;
 	do {
 		$matcher = 'match_'.'Value'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) {
 			$this->store( $result, $subres, "core" );
 		}
-		else { $_108 = \false; break; }
+		else { $_113 = \false; break; }
 		while (\true) {
-			$res_107 = $result;
-			$pos_107 = $this->pos;
-			$_106 = \null;
+			$res_112 = $result;
+			$pos_112 = $this->pos;
+			$_111 = \null;
 			do {
 				if (\substr($this->string,$this->pos,1) === '[') {
 					$this->pos += 1;
 					$result["text"] .= '[';
 				}
-				else { $_106 = \false; break; }
+				else { $_111 = \false; break; }
 				$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 				if ($subres !== \false) { $this->store( $result, $subres ); }
-				else { $_106 = \false; break; }
+				else { $_111 = \false; break; }
 				$matcher = 'match_'.'Expression'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 				if ($subres !== \false) {
 					$this->store( $result, $subres, "dereference" );
 				}
-				else { $_106 = \false; break; }
+				else { $_111 = \false; break; }
 				$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 				if ($subres !== \false) { $this->store( $result, $subres ); }
-				else { $_106 = \false; break; }
+				else { $_111 = \false; break; }
 				if (\substr($this->string,$this->pos,1) === ']') {
 					$this->pos += 1;
 					$result["text"] .= ']';
 				}
-				else { $_106 = \false; break; }
-				$_106 = \true; break;
+				else { $_111 = \false; break; }
+				$_111 = \true; break;
 			}
 			while(0);
-			if( $_106 === \false) {
-				$result = $res_107;
-				$this->pos = $pos_107;
-				unset( $res_107 );
-				unset( $pos_107 );
+			if( $_111 === \false) {
+				$result = $res_112;
+				$this->pos = $pos_112;
+				unset( $res_112 );
+				unset( $pos_112 );
 				break;
 			}
 		}
-		$_108 = \true; break;
+		$_113 = \true; break;
 	}
 	while(0);
-	if( $_108 === \true ) { return $this->finalise($result); }
-	if( $_108 === \false) { return \false; }
+	if( $_113 === \true ) { return $this->finalise($result); }
+	if( $_113 === \false) { return \false; }
 }
 
 
@@ -656,89 +686,89 @@ function match_DereferencableValue ($stack = []) {
 protected $match_VariableVector_typestack = array('VariableVector');
 function match_VariableVector ($stack = []) {
 	$matchrule = "VariableVector"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_124 = \null;
+	$_129 = \null;
 	do {
 		$matcher = 'match_'.'Variable'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) {
 			$this->store( $result, $subres, "core" );
 		}
-		else { $_124 = \false; break; }
+		else { $_129 = \false; break; }
 		$count = 0;
 		while (\true) {
-			$res_123 = $result;
-			$pos_123 = $this->pos;
-			$_122 = \null;
+			$res_128 = $result;
+			$pos_128 = $this->pos;
+			$_127 = \null;
 			do {
 				if (\substr($this->string,$this->pos,1) === '[') {
 					$this->pos += 1;
 					$result["text"] .= '[';
 				}
-				else { $_122 = \false; break; }
+				else { $_127 = \false; break; }
 				$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 				if ($subres !== \false) { $this->store( $result, $subres ); }
-				else { $_122 = \false; break; }
-				$_118 = \null;
+				else { $_127 = \false; break; }
+				$_123 = \null;
 				do {
-					$_116 = \null;
+					$_121 = \null;
 					do {
-						$res_113 = $result;
-						$pos_113 = $this->pos;
+						$res_118 = $result;
+						$pos_118 = $this->pos;
 						$matcher = 'match_'.'Expression'; $key = $matcher; $pos = $this->pos;
 						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 						if ($subres !== \false) {
 							$this->store( $result, $subres, "vector" );
-							$_116 = \true; break;
+							$_121 = \true; break;
 						}
-						$result = $res_113;
-						$this->pos = $pos_113;
+						$result = $res_118;
+						$this->pos = $pos_118;
 						$stack[] = $result; $result = $this->construct( $matchrule, "vector" ); 
 						if (( $subres = $this->literal( '' ) ) !== \false) {
 							$result["text"] .= $subres;
 							$subres = $result; $result = \array_pop($stack);
 							$this->store( $result, $subres, 'vector' );
-							$_116 = \true; break;
+							$_121 = \true; break;
 						}
 						else { $result = \array_pop($stack); }
-						$result = $res_113;
-						$this->pos = $pos_113;
-						$_116 = \false; break;
+						$result = $res_118;
+						$this->pos = $pos_118;
+						$_121 = \false; break;
 					}
 					while(0);
-					if( $_116 === \false) { $_118 = \false; break; }
-					$_118 = \true; break;
+					if( $_121 === \false) { $_123 = \false; break; }
+					$_123 = \true; break;
 				}
 				while(0);
-				if( $_118 === \false) { $_122 = \false; break; }
+				if( $_123 === \false) { $_127 = \false; break; }
 				$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 				if ($subres !== \false) { $this->store( $result, $subres ); }
-				else { $_122 = \false; break; }
+				else { $_127 = \false; break; }
 				if (\substr($this->string,$this->pos,1) === ']') {
 					$this->pos += 1;
 					$result["text"] .= ']';
 				}
-				else { $_122 = \false; break; }
-				$_122 = \true; break;
+				else { $_127 = \false; break; }
+				$_127 = \true; break;
 			}
 			while(0);
-			if( $_122 === \false) {
-				$result = $res_123;
-				$this->pos = $pos_123;
-				unset( $res_123 );
-				unset( $pos_123 );
+			if( $_127 === \false) {
+				$result = $res_128;
+				$this->pos = $pos_128;
+				unset( $res_128 );
+				unset( $pos_128 );
 				break;
 			}
 			$count++;
 		}
 		if ($count >= 1) {  }
-		else { $_124 = \false; break; }
-		$_124 = \true; break;
+		else { $_129 = \false; break; }
+		$_129 = \true; break;
 	}
 	while(0);
-	if( $_124 === \true ) { return $this->finalise($result); }
-	if( $_124 === \false) { return \false; }
+	if( $_129 === \true ) { return $this->finalise($result); }
+	if( $_129 === \false) { return \false; }
 }
 
 
@@ -746,31 +776,31 @@ function match_VariableVector ($stack = []) {
 protected $match_Mutable_typestack = array('Mutable');
 function match_Mutable ($stack = []) {
 	$matchrule = "Mutable"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_129 = \null;
+	$_134 = \null;
 	do {
-		$res_126 = $result;
-		$pos_126 = $this->pos;
+		$res_131 = $result;
+		$pos_131 = $this->pos;
 		$matcher = 'match_'.'VariableVector'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) {
 			$this->store( $result, $subres, "skip" );
-			$_129 = \true; break;
+			$_134 = \true; break;
 		}
-		$result = $res_126;
-		$this->pos = $pos_126;
+		$result = $res_131;
+		$this->pos = $pos_131;
 		$matcher = 'match_'.'VariableName'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) {
 			$this->store( $result, $subres, "skip" );
-			$_129 = \true; break;
+			$_134 = \true; break;
 		}
-		$result = $res_126;
-		$this->pos = $pos_126;
-		$_129 = \false; break;
+		$result = $res_131;
+		$this->pos = $pos_131;
+		$_134 = \false; break;
 	}
 	while(0);
-	if( $_129 === \true ) { return $this->finalise($result); }
-	if( $_129 === \false) { return \false; }
+	if( $_134 === \true ) { return $this->finalise($result); }
+	if( $_134 === \false) { return \false; }
 }
 
 
@@ -791,50 +821,20 @@ function match_ObjectResolutionOperator ($stack = []) {
 protected $match_AddOperator_typestack = array('AddOperator');
 function match_AddOperator ($stack = []) {
 	$matchrule = "AddOperator"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_135 = \null;
-	do {
-		$res_132 = $result;
-		$pos_132 = $this->pos;
-		if (\substr($this->string,$this->pos,1) === '+') {
-			$this->pos += 1;
-			$result["text"] .= '+';
-			$_135 = \true; break;
-		}
-		$result = $res_132;
-		$this->pos = $pos_132;
-		if (\substr($this->string,$this->pos,1) === '-') {
-			$this->pos += 1;
-			$result["text"] .= '-';
-			$_135 = \true; break;
-		}
-		$result = $res_132;
-		$this->pos = $pos_132;
-		$_135 = \false; break;
-	}
-	while(0);
-	if( $_135 === \true ) { return $this->finalise($result); }
-	if( $_135 === \false) { return \false; }
-}
-
-
-/* MultiplyOperator: "*" | "/" */
-protected $match_MultiplyOperator_typestack = array('MultiplyOperator');
-function match_MultiplyOperator ($stack = []) {
-	$matchrule = "MultiplyOperator"; $result = $this->construct($matchrule, $matchrule, \null);
 	$_140 = \null;
 	do {
 		$res_137 = $result;
 		$pos_137 = $this->pos;
-		if (\substr($this->string,$this->pos,1) === '*') {
+		if (\substr($this->string,$this->pos,1) === '+') {
 			$this->pos += 1;
-			$result["text"] .= '*';
+			$result["text"] .= '+';
 			$_140 = \true; break;
 		}
 		$result = $res_137;
 		$this->pos = $pos_137;
-		if (\substr($this->string,$this->pos,1) === '/') {
+		if (\substr($this->string,$this->pos,1) === '-') {
 			$this->pos += 1;
-			$result["text"] .= '/';
+			$result["text"] .= '-';
 			$_140 = \true; break;
 		}
 		$result = $res_137;
@@ -844,6 +844,36 @@ function match_MultiplyOperator ($stack = []) {
 	while(0);
 	if( $_140 === \true ) { return $this->finalise($result); }
 	if( $_140 === \false) { return \false; }
+}
+
+
+/* MultiplyOperator: "*" | "/" */
+protected $match_MultiplyOperator_typestack = array('MultiplyOperator');
+function match_MultiplyOperator ($stack = []) {
+	$matchrule = "MultiplyOperator"; $result = $this->construct($matchrule, $matchrule, \null);
+	$_145 = \null;
+	do {
+		$res_142 = $result;
+		$pos_142 = $this->pos;
+		if (\substr($this->string,$this->pos,1) === '*') {
+			$this->pos += 1;
+			$result["text"] .= '*';
+			$_145 = \true; break;
+		}
+		$result = $res_142;
+		$this->pos = $pos_142;
+		if (\substr($this->string,$this->pos,1) === '/') {
+			$this->pos += 1;
+			$result["text"] .= '/';
+			$_145 = \true; break;
+		}
+		$result = $res_142;
+		$this->pos = $pos_142;
+		$_145 = \false; break;
+	}
+	while(0);
+	if( $_145 === \true ) { return $this->finalise($result); }
+	if( $_145 === \false) { return \false; }
 }
 
 
@@ -864,116 +894,88 @@ function match_AssignmentOperator ($stack = []) {
 protected $match_ComparisonOperator_typestack = array('ComparisonOperator');
 function match_ComparisonOperator ($stack = []) {
 	$matchrule = "ComparisonOperator"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_162 = \null;
+	$_167 = \null;
 	do {
-		$res_143 = $result;
-		$pos_143 = $this->pos;
+		$res_148 = $result;
+		$pos_148 = $this->pos;
 		if (( $subres = $this->literal( '==' ) ) !== \false) {
 			$result["text"] .= $subres;
-			$_162 = \true; break;
+			$_167 = \true; break;
 		}
-		$result = $res_143;
-		$this->pos = $pos_143;
-		$_160 = \null;
+		$result = $res_148;
+		$this->pos = $pos_148;
+		$_165 = \null;
 		do {
-			$res_145 = $result;
-			$pos_145 = $this->pos;
+			$res_150 = $result;
+			$pos_150 = $this->pos;
 			if (( $subres = $this->literal( '!=' ) ) !== \false) {
 				$result["text"] .= $subres;
-				$_160 = \true; break;
+				$_165 = \true; break;
 			}
-			$result = $res_145;
-			$this->pos = $pos_145;
-			$_158 = \null;
+			$result = $res_150;
+			$this->pos = $pos_150;
+			$_163 = \null;
 			do {
-				$res_147 = $result;
-				$pos_147 = $this->pos;
+				$res_152 = $result;
+				$pos_152 = $this->pos;
 				if (( $subres = $this->literal( '>=' ) ) !== \false) {
 					$result["text"] .= $subres;
-					$_158 = \true; break;
+					$_163 = \true; break;
 				}
-				$result = $res_147;
-				$this->pos = $pos_147;
-				$_156 = \null;
+				$result = $res_152;
+				$this->pos = $pos_152;
+				$_161 = \null;
 				do {
-					$res_149 = $result;
-					$pos_149 = $this->pos;
+					$res_154 = $result;
+					$pos_154 = $this->pos;
 					if (( $subres = $this->literal( '<=' ) ) !== \false) {
 						$result["text"] .= $subres;
-						$_156 = \true; break;
+						$_161 = \true; break;
 					}
-					$result = $res_149;
-					$this->pos = $pos_149;
-					$_154 = \null;
+					$result = $res_154;
+					$this->pos = $pos_154;
+					$_159 = \null;
 					do {
-						$res_151 = $result;
-						$pos_151 = $this->pos;
+						$res_156 = $result;
+						$pos_156 = $this->pos;
 						if (\substr($this->string,$this->pos,1) === '>') {
 							$this->pos += 1;
 							$result["text"] .= '>';
-							$_154 = \true; break;
+							$_159 = \true; break;
 						}
-						$result = $res_151;
-						$this->pos = $pos_151;
+						$result = $res_156;
+						$this->pos = $pos_156;
 						if (\substr($this->string,$this->pos,1) === '<') {
 							$this->pos += 1;
 							$result["text"] .= '<';
-							$_154 = \true; break;
+							$_159 = \true; break;
 						}
-						$result = $res_151;
-						$this->pos = $pos_151;
-						$_154 = \false; break;
+						$result = $res_156;
+						$this->pos = $pos_156;
+						$_159 = \false; break;
 					}
 					while(0);
-					if( $_154 === \true ) { $_156 = \true; break; }
-					$result = $res_149;
-					$this->pos = $pos_149;
-					$_156 = \false; break;
+					if( $_159 === \true ) { $_161 = \true; break; }
+					$result = $res_154;
+					$this->pos = $pos_154;
+					$_161 = \false; break;
 				}
 				while(0);
-				if( $_156 === \true ) { $_158 = \true; break; }
-				$result = $res_147;
-				$this->pos = $pos_147;
-				$_158 = \false; break;
+				if( $_161 === \true ) { $_163 = \true; break; }
+				$result = $res_152;
+				$this->pos = $pos_152;
+				$_163 = \false; break;
 			}
 			while(0);
-			if( $_158 === \true ) { $_160 = \true; break; }
-			$result = $res_145;
-			$this->pos = $pos_145;
-			$_160 = \false; break;
+			if( $_163 === \true ) { $_165 = \true; break; }
+			$result = $res_150;
+			$this->pos = $pos_150;
+			$_165 = \false; break;
 		}
 		while(0);
-		if( $_160 === \true ) { $_162 = \true; break; }
-		$result = $res_143;
-		$this->pos = $pos_143;
-		$_162 = \false; break;
-	}
-	while(0);
-	if( $_162 === \true ) { return $this->finalise($result); }
-	if( $_162 === \false) { return \false; }
-}
-
-
-/* UnaryOperator: "++" | "--" */
-protected $match_UnaryOperator_typestack = array('UnaryOperator');
-function match_UnaryOperator ($stack = []) {
-	$matchrule = "UnaryOperator"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_167 = \null;
-	do {
-		$res_164 = $result;
-		$pos_164 = $this->pos;
-		if (( $subres = $this->literal( '++' ) ) !== \false) {
-			$result["text"] .= $subres;
-			$_167 = \true; break;
-		}
-		$result = $res_164;
-		$this->pos = $pos_164;
-		if (( $subres = $this->literal( '--' ) ) !== \false) {
-			$result["text"] .= $subres;
-			$_167 = \true; break;
-		}
-		$result = $res_164;
-		$this->pos = $pos_164;
+		if( $_165 === \true ) { $_167 = \true; break; }
+		$result = $res_148;
+		$this->pos = $pos_148;
 		$_167 = \false; break;
 	}
 	while(0);
@@ -982,71 +984,99 @@ function match_UnaryOperator ($stack = []) {
 }
 
 
+/* UnaryOperator: "++" | "--" */
+protected $match_UnaryOperator_typestack = array('UnaryOperator');
+function match_UnaryOperator ($stack = []) {
+	$matchrule = "UnaryOperator"; $result = $this->construct($matchrule, $matchrule, \null);
+	$_172 = \null;
+	do {
+		$res_169 = $result;
+		$pos_169 = $this->pos;
+		if (( $subres = $this->literal( '++' ) ) !== \false) {
+			$result["text"] .= $subres;
+			$_172 = \true; break;
+		}
+		$result = $res_169;
+		$this->pos = $pos_169;
+		if (( $subres = $this->literal( '--' ) ) !== \false) {
+			$result["text"] .= $subres;
+			$_172 = \true; break;
+		}
+		$result = $res_169;
+		$this->pos = $pos_169;
+		$_172 = \false; break;
+	}
+	while(0);
+	if( $_172 === \true ) { return $this->finalise($result); }
+	if( $_172 === \false) { return \false; }
+}
+
+
 /* Expression: skip:AnonymousFunction | skip:Assignment | skip:Comparison | skip:Addition */
 protected $match_Expression_typestack = array('Expression');
 function match_Expression ($stack = []) {
 	$matchrule = "Expression"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_180 = \null;
+	$_185 = \null;
 	do {
-		$res_169 = $result;
-		$pos_169 = $this->pos;
+		$res_174 = $result;
+		$pos_174 = $this->pos;
 		$matcher = 'match_'.'AnonymousFunction'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) {
 			$this->store( $result, $subres, "skip" );
-			$_180 = \true; break;
+			$_185 = \true; break;
 		}
-		$result = $res_169;
-		$this->pos = $pos_169;
-		$_178 = \null;
+		$result = $res_174;
+		$this->pos = $pos_174;
+		$_183 = \null;
 		do {
-			$res_171 = $result;
-			$pos_171 = $this->pos;
+			$res_176 = $result;
+			$pos_176 = $this->pos;
 			$matcher = 'match_'.'Assignment'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 			if ($subres !== \false) {
 				$this->store( $result, $subres, "skip" );
-				$_178 = \true; break;
+				$_183 = \true; break;
 			}
-			$result = $res_171;
-			$this->pos = $pos_171;
-			$_176 = \null;
+			$result = $res_176;
+			$this->pos = $pos_176;
+			$_181 = \null;
 			do {
-				$res_173 = $result;
-				$pos_173 = $this->pos;
+				$res_178 = $result;
+				$pos_178 = $this->pos;
 				$matcher = 'match_'.'Comparison'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 				if ($subres !== \false) {
 					$this->store( $result, $subres, "skip" );
-					$_176 = \true; break;
+					$_181 = \true; break;
 				}
-				$result = $res_173;
-				$this->pos = $pos_173;
+				$result = $res_178;
+				$this->pos = $pos_178;
 				$matcher = 'match_'.'Addition'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 				if ($subres !== \false) {
 					$this->store( $result, $subres, "skip" );
-					$_176 = \true; break;
+					$_181 = \true; break;
 				}
-				$result = $res_173;
-				$this->pos = $pos_173;
-				$_176 = \false; break;
+				$result = $res_178;
+				$this->pos = $pos_178;
+				$_181 = \false; break;
 			}
 			while(0);
-			if( $_176 === \true ) { $_178 = \true; break; }
-			$result = $res_171;
-			$this->pos = $pos_171;
-			$_178 = \false; break;
+			if( $_181 === \true ) { $_183 = \true; break; }
+			$result = $res_176;
+			$this->pos = $pos_176;
+			$_183 = \false; break;
 		}
 		while(0);
-		if( $_178 === \true ) { $_180 = \true; break; }
-		$result = $res_169;
-		$this->pos = $pos_169;
-		$_180 = \false; break;
+		if( $_183 === \true ) { $_185 = \true; break; }
+		$result = $res_174;
+		$this->pos = $pos_174;
+		$_185 = \false; break;
 	}
 	while(0);
-	if( $_180 === \true ) { return $this->finalise($result); }
-	if( $_180 === \false) { return \false; }
+	if( $_185 === \true ) { return $this->finalise($result); }
+	if( $_185 === \false) { return \false; }
 }
 
 
@@ -1054,39 +1084,39 @@ function match_Expression ($stack = []) {
 protected $match_Comparison_typestack = array('Comparison');
 function match_Comparison ($stack = []) {
 	$matchrule = "Comparison"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_187 = \null;
+	$_192 = \null;
 	do {
 		$matcher = 'match_'.'Addition'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) {
 			$this->store( $result, $subres, "left" );
 		}
-		else { $_187 = \false; break; }
+		else { $_192 = \false; break; }
 		$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) { $this->store( $result, $subres ); }
-		else { $_187 = \false; break; }
+		else { $_192 = \false; break; }
 		$matcher = 'match_'.'ComparisonOperator'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) {
 			$this->store( $result, $subres, "op" );
 		}
-		else { $_187 = \false; break; }
+		else { $_192 = \false; break; }
 		$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) { $this->store( $result, $subres ); }
-		else { $_187 = \false; break; }
+		else { $_192 = \false; break; }
 		$matcher = 'match_'.'Addition'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) {
 			$this->store( $result, $subres, "right" );
 		}
-		else { $_187 = \false; break; }
-		$_187 = \true; break;
+		else { $_192 = \false; break; }
+		$_192 = \true; break;
 	}
 	while(0);
-	if( $_187 === \true ) { return $this->finalise($result); }
-	if( $_187 === \false) { return \false; }
+	if( $_192 === \true ) { return $this->finalise($result); }
+	if( $_192 === \false) { return \false; }
 }
 
 
@@ -1094,39 +1124,39 @@ function match_Comparison ($stack = []) {
 protected $match_Assignment_typestack = array('Assignment');
 function match_Assignment ($stack = []) {
 	$matchrule = "Assignment"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_194 = \null;
+	$_199 = \null;
 	do {
 		$matcher = 'match_'.'Mutable'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) {
 			$this->store( $result, $subres, "left" );
 		}
-		else { $_194 = \false; break; }
+		else { $_199 = \false; break; }
 		$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) { $this->store( $result, $subres ); }
-		else { $_194 = \false; break; }
+		else { $_199 = \false; break; }
 		$matcher = 'match_'.'AssignmentOperator'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) {
 			$this->store( $result, $subres, "op" );
 		}
-		else { $_194 = \false; break; }
+		else { $_199 = \false; break; }
 		$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) { $this->store( $result, $subres ); }
-		else { $_194 = \false; break; }
+		else { $_199 = \false; break; }
 		$matcher = 'match_'.'Expression'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) {
 			$this->store( $result, $subres, "right" );
 		}
-		else { $_194 = \false; break; }
-		$_194 = \true; break;
+		else { $_199 = \false; break; }
+		$_199 = \true; break;
 	}
 	while(0);
-	if( $_194 === \true ) { return $this->finalise($result); }
-	if( $_194 === \false) { return \false; }
+	if( $_199 === \true ) { return $this->finalise($result); }
+	if( $_199 === \false) { return \false; }
 }
 
 
@@ -1134,55 +1164,55 @@ function match_Assignment ($stack = []) {
 protected $match_Addition_typestack = array('Addition');
 function match_Addition ($stack = []) {
 	$matchrule = "Addition"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_203 = \null;
+	$_208 = \null;
 	do {
 		$matcher = 'match_'.'Multiplication'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) {
 			$this->store( $result, $subres, "operands" );
 		}
-		else { $_203 = \false; break; }
+		else { $_208 = \false; break; }
 		while (\true) {
-			$res_202 = $result;
-			$pos_202 = $this->pos;
-			$_201 = \null;
+			$res_207 = $result;
+			$pos_207 = $this->pos;
+			$_206 = \null;
 			do {
 				$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 				if ($subres !== \false) { $this->store( $result, $subres ); }
-				else { $_201 = \false; break; }
+				else { $_206 = \false; break; }
 				$matcher = 'match_'.'AddOperator'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 				if ($subres !== \false) {
 					$this->store( $result, $subres, "ops" );
 				}
-				else { $_201 = \false; break; }
+				else { $_206 = \false; break; }
 				$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 				if ($subres !== \false) { $this->store( $result, $subres ); }
-				else { $_201 = \false; break; }
+				else { $_206 = \false; break; }
 				$matcher = 'match_'.'Multiplication'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 				if ($subres !== \false) {
 					$this->store( $result, $subres, "operands" );
 				}
-				else { $_201 = \false; break; }
-				$_201 = \true; break;
+				else { $_206 = \false; break; }
+				$_206 = \true; break;
 			}
 			while(0);
-			if( $_201 === \false) {
-				$result = $res_202;
-				$this->pos = $pos_202;
-				unset( $res_202 );
-				unset( $pos_202 );
+			if( $_206 === \false) {
+				$result = $res_207;
+				$this->pos = $pos_207;
+				unset( $res_207 );
+				unset( $pos_207 );
 				break;
 			}
 		}
-		$_203 = \true; break;
+		$_208 = \true; break;
 	}
 	while(0);
-	if( $_203 === \true ) { return $this->finalise($result); }
-	if( $_203 === \false) { return \false; }
+	if( $_208 === \true ) { return $this->finalise($result); }
+	if( $_208 === \false) { return \false; }
 }
 
 
@@ -1190,55 +1220,55 @@ function match_Addition ($stack = []) {
 protected $match_Multiplication_typestack = array('Multiplication');
 function match_Multiplication ($stack = []) {
 	$matchrule = "Multiplication"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_212 = \null;
+	$_217 = \null;
 	do {
 		$matcher = 'match_'.'Operand'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) {
 			$this->store( $result, $subres, "operands" );
 		}
-		else { $_212 = \false; break; }
+		else { $_217 = \false; break; }
 		while (\true) {
-			$res_211 = $result;
-			$pos_211 = $this->pos;
-			$_210 = \null;
+			$res_216 = $result;
+			$pos_216 = $this->pos;
+			$_215 = \null;
 			do {
 				$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 				if ($subres !== \false) { $this->store( $result, $subres ); }
-				else { $_210 = \false; break; }
+				else { $_215 = \false; break; }
 				$matcher = 'match_'.'MultiplyOperator'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 				if ($subres !== \false) {
 					$this->store( $result, $subres, "ops" );
 				}
-				else { $_210 = \false; break; }
+				else { $_215 = \false; break; }
 				$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 				if ($subres !== \false) { $this->store( $result, $subres ); }
-				else { $_210 = \false; break; }
+				else { $_215 = \false; break; }
 				$matcher = 'match_'.'Operand'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 				if ($subres !== \false) {
 					$this->store( $result, $subres, "operands" );
 				}
-				else { $_210 = \false; break; }
-				$_210 = \true; break;
+				else { $_215 = \false; break; }
+				$_215 = \true; break;
 			}
 			while(0);
-			if( $_210 === \false) {
-				$result = $res_211;
-				$this->pos = $pos_211;
-				unset( $res_211 );
-				unset( $pos_211 );
+			if( $_215 === \false) {
+				$result = $res_216;
+				$this->pos = $pos_216;
+				unset( $res_216 );
+				unset( $pos_216 );
 				break;
 			}
 		}
-		$_212 = \true; break;
+		$_217 = \true; break;
 	}
 	while(0);
-	if( $_212 === \true ) { return $this->finalise($result); }
-	if( $_212 === \false) { return \false; }
+	if( $_217 === \true ) { return $this->finalise($result); }
+	if( $_217 === \false) { return \false; }
 }
 
 
@@ -1246,66 +1276,66 @@ function match_Multiplication ($stack = []) {
 protected $match_Chain_typestack = array('Chain');
 function match_Chain ($stack = []) {
 	$matchrule = "Chain"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_225 = \null;
+	$_230 = \null;
 	do {
 		$matcher = 'match_'.'ObjectResolutionOperator'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) { $this->store( $result, $subres ); }
-		else { $_225 = \false; break; }
-		$_220 = \null;
+		else { $_230 = \false; break; }
+		$_225 = \null;
 		do {
-			$_218 = \null;
+			$_223 = \null;
 			do {
-				$res_215 = $result;
-				$pos_215 = $this->pos;
+				$res_220 = $result;
+				$pos_220 = $this->pos;
 				$matcher = 'match_'.'MethodCall'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 				if ($subres !== \false) {
 					$this->store( $result, $subres, "core" );
-					$_218 = \true; break;
+					$_223 = \true; break;
 				}
-				$result = $res_215;
-				$this->pos = $pos_215;
+				$result = $res_220;
+				$this->pos = $pos_220;
 				$matcher = 'match_'.'PropertyGetter'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 				if ($subres !== \false) {
 					$this->store( $result, $subres, "core" );
-					$_218 = \true; break;
+					$_223 = \true; break;
 				}
-				$result = $res_215;
-				$this->pos = $pos_215;
-				$_218 = \false; break;
+				$result = $res_220;
+				$this->pos = $pos_220;
+				$_223 = \false; break;
 			}
 			while(0);
-			if( $_218 === \false) { $_220 = \false; break; }
-			$_220 = \true; break;
+			if( $_223 === \false) { $_225 = \false; break; }
+			$_225 = \true; break;
 		}
 		while(0);
-		if( $_220 === \false) { $_225 = \false; break; }
-		$res_224 = $result;
-		$pos_224 = $this->pos;
-		$_223 = \null;
+		if( $_225 === \false) { $_230 = \false; break; }
+		$res_229 = $result;
+		$pos_229 = $this->pos;
+		$_228 = \null;
 		do {
 			$matcher = 'match_'.'Chain'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 			if ($subres !== \false) {
 				$this->store( $result, $subres, "chain" );
 			}
-			else { $_223 = \false; break; }
-			$_223 = \true; break;
+			else { $_228 = \false; break; }
+			$_228 = \true; break;
 		}
 		while(0);
-		if( $_223 === \false) {
-			$result = $res_224;
-			$this->pos = $pos_224;
-			unset( $res_224 );
-			unset( $pos_224 );
+		if( $_228 === \false) {
+			$result = $res_229;
+			$this->pos = $pos_229;
+			unset( $res_229 );
+			unset( $pos_229 );
 		}
-		$_225 = \true; break;
+		$_230 = \true; break;
 	}
 	while(0);
-	if( $_225 === \true ) { return $this->finalise($result); }
-	if( $_225 === \false) { return \false; }
+	if( $_230 === \true ) { return $this->finalise($result); }
+	if( $_230 === \false) { return \false; }
 }
 
 
@@ -1313,108 +1343,108 @@ function match_Chain ($stack = []) {
 protected $match_Operand_typestack = array('Operand');
 function match_Operand ($stack = []) {
 	$matchrule = "Operand"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_247 = \null;
+	$_252 = \null;
 	do {
-		$_242 = \null;
+		$_247 = \null;
 		do {
-			$_240 = \null;
+			$_245 = \null;
 			do {
-				$res_227 = $result;
-				$pos_227 = $this->pos;
+				$res_232 = $result;
+				$pos_232 = $this->pos;
 				$matcher = 'match_'.'FunctionCall'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 				if ($subres !== \false) {
 					$this->store( $result, $subres, "core" );
-					$_240 = \true; break;
+					$_245 = \true; break;
 				}
-				$result = $res_227;
-				$this->pos = $pos_227;
-				$_238 = \null;
+				$result = $res_232;
+				$this->pos = $pos_232;
+				$_243 = \null;
 				do {
-					$res_229 = $result;
-					$pos_229 = $this->pos;
-					$_235 = \null;
+					$res_234 = $result;
+					$pos_234 = $this->pos;
+					$_240 = \null;
 					do {
 						if (\substr($this->string,$this->pos,1) === '(') {
 							$this->pos += 1;
 							$result["text"] .= '(';
 						}
-						else { $_235 = \false; break; }
+						else { $_240 = \false; break; }
 						$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 						if ($subres !== \false) {
 							$this->store( $result, $subres );
 						}
-						else { $_235 = \false; break; }
+						else { $_240 = \false; break; }
 						$matcher = 'match_'.'Expression'; $key = $matcher; $pos = $this->pos;
 						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 						if ($subres !== \false) {
 							$this->store( $result, $subres, "core" );
 						}
-						else { $_235 = \false; break; }
+						else { $_240 = \false; break; }
 						$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 						if ($subres !== \false) {
 							$this->store( $result, $subres );
 						}
-						else { $_235 = \false; break; }
+						else { $_240 = \false; break; }
 						if (\substr($this->string,$this->pos,1) === ')') {
 							$this->pos += 1;
 							$result["text"] .= ')';
 						}
-						else { $_235 = \false; break; }
-						$_235 = \true; break;
+						else { $_240 = \false; break; }
+						$_240 = \true; break;
 					}
 					while(0);
-					if( $_235 === \true ) { $_238 = \true; break; }
-					$result = $res_229;
-					$this->pos = $pos_229;
+					if( $_240 === \true ) { $_243 = \true; break; }
+					$result = $res_234;
+					$this->pos = $pos_234;
 					$matcher = 'match_'.'DereferencableValue'; $key = $matcher; $pos = $this->pos;
 					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 					if ($subres !== \false) {
 						$this->store( $result, $subres, "core" );
-						$_238 = \true; break;
+						$_243 = \true; break;
 					}
-					$result = $res_229;
-					$this->pos = $pos_229;
-					$_238 = \false; break;
+					$result = $res_234;
+					$this->pos = $pos_234;
+					$_243 = \false; break;
 				}
 				while(0);
-				if( $_238 === \true ) { $_240 = \true; break; }
-				$result = $res_227;
-				$this->pos = $pos_227;
-				$_240 = \false; break;
+				if( $_243 === \true ) { $_245 = \true; break; }
+				$result = $res_232;
+				$this->pos = $pos_232;
+				$_245 = \false; break;
 			}
 			while(0);
-			if( $_240 === \false) { $_242 = \false; break; }
-			$_242 = \true; break;
+			if( $_245 === \false) { $_247 = \false; break; }
+			$_247 = \true; break;
 		}
 		while(0);
-		if( $_242 === \false) { $_247 = \false; break; }
-		$res_246 = $result;
-		$pos_246 = $this->pos;
-		$_245 = \null;
+		if( $_247 === \false) { $_252 = \false; break; }
+		$res_251 = $result;
+		$pos_251 = $this->pos;
+		$_250 = \null;
 		do {
 			$matcher = 'match_'.'Chain'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 			if ($subres !== \false) {
 				$this->store( $result, $subres, "chain" );
 			}
-			else { $_245 = \false; break; }
-			$_245 = \true; break;
+			else { $_250 = \false; break; }
+			$_250 = \true; break;
 		}
 		while(0);
-		if( $_245 === \false) {
-			$result = $res_246;
-			$this->pos = $pos_246;
-			unset( $res_246 );
-			unset( $pos_246 );
+		if( $_250 === \false) {
+			$result = $res_251;
+			$this->pos = $pos_251;
+			unset( $res_251 );
+			unset( $pos_251 );
 		}
-		$_247 = \true; break;
+		$_252 = \true; break;
 	}
 	while(0);
-	if( $_247 === \true ) { return $this->finalise($result); }
-	if( $_247 === \false) { return \false; }
+	if( $_252 === \true ) { return $this->finalise($result); }
+	if( $_252 === \false) { return \false; }
 }
 
 
@@ -1422,50 +1452,50 @@ function match_Operand ($stack = []) {
 protected $match_MethodCall_typestack = array('MethodCall');
 function match_MethodCall ($stack = []) {
 	$matchrule = "MethodCall"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_255 = \null;
+	$_260 = \null;
 	do {
 		$matcher = 'match_'.'VariableName'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) {
 			$this->store( $result, $subres, "method" );
 		}
-		else { $_255 = \false; break; }
+		else { $_260 = \false; break; }
 		if (\substr($this->string,$this->pos,1) === '(') {
 			$this->pos += 1;
 			$result["text"] .= '(';
 		}
-		else { $_255 = \false; break; }
+		else { $_260 = \false; break; }
 		$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) { $this->store( $result, $subres ); }
-		else { $_255 = \false; break; }
-		$res_252 = $result;
-		$pos_252 = $this->pos;
+		else { $_260 = \false; break; }
+		$res_257 = $result;
+		$pos_257 = $this->pos;
 		$matcher = 'match_'.'ArgumentList'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) {
 			$this->store( $result, $subres, "args" );
 		}
 		else {
-			$result = $res_252;
-			$this->pos = $pos_252;
-			unset( $res_252 );
-			unset( $pos_252 );
+			$result = $res_257;
+			$this->pos = $pos_257;
+			unset( $res_257 );
+			unset( $pos_257 );
 		}
 		$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) { $this->store( $result, $subres ); }
-		else { $_255 = \false; break; }
+		else { $_260 = \false; break; }
 		if (\substr($this->string,$this->pos,1) === ')') {
 			$this->pos += 1;
 			$result["text"] .= ')';
 		}
-		else { $_255 = \false; break; }
-		$_255 = \true; break;
+		else { $_260 = \false; break; }
+		$_260 = \true; break;
 	}
 	while(0);
-	if( $_255 === \true ) { return $this->finalise($result); }
-	if( $_255 === \false) { return \false; }
+	if( $_260 === \true ) { return $this->finalise($result); }
+	if( $_260 === \false) { return \false; }
 }
 
 
@@ -1473,98 +1503,98 @@ function match_MethodCall ($stack = []) {
 protected $match_FunctionCall_typestack = array('FunctionCall');
 function match_FunctionCall ($stack = []) {
 	$matchrule = "FunctionCall"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_275 = \null;
+	$_280 = \null;
 	do {
-		$_268 = \null;
+		$_273 = \null;
 		do {
-			$_266 = \null;
+			$_271 = \null;
 			do {
-				$res_257 = $result;
-				$pos_257 = $this->pos;
+				$res_262 = $result;
+				$pos_262 = $this->pos;
 				$matcher = 'match_'.'VariableName'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 				if ($subres !== \false) {
 					$this->store( $result, $subres, "variable" );
-					$_266 = \true; break;
+					$_271 = \true; break;
 				}
-				$result = $res_257;
-				$this->pos = $pos_257;
-				$_264 = \null;
+				$result = $res_262;
+				$this->pos = $pos_262;
+				$_269 = \null;
 				do {
 					if (\substr($this->string,$this->pos,1) === '(') {
 						$this->pos += 1;
 						$result["text"] .= '(';
 					}
-					else { $_264 = \false; break; }
+					else { $_269 = \false; break; }
 					$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 					if ($subres !== \false) { $this->store( $result, $subres ); }
-					else { $_264 = \false; break; }
+					else { $_269 = \false; break; }
 					$matcher = 'match_'.'Expression'; $key = $matcher; $pos = $this->pos;
 					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 					if ($subres !== \false) {
 						$this->store( $result, $subres, "value" );
 					}
-					else { $_264 = \false; break; }
+					else { $_269 = \false; break; }
 					$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 					if ($subres !== \false) { $this->store( $result, $subres ); }
-					else { $_264 = \false; break; }
+					else { $_269 = \false; break; }
 					if (\substr($this->string,$this->pos,1) === ')') {
 						$this->pos += 1;
 						$result["text"] .= ')';
 					}
-					else { $_264 = \false; break; }
-					$_264 = \true; break;
+					else { $_269 = \false; break; }
+					$_269 = \true; break;
 				}
 				while(0);
-				if( $_264 === \true ) { $_266 = \true; break; }
-				$result = $res_257;
-				$this->pos = $pos_257;
-				$_266 = \false; break;
+				if( $_269 === \true ) { $_271 = \true; break; }
+				$result = $res_262;
+				$this->pos = $pos_262;
+				$_271 = \false; break;
 			}
 			while(0);
-			if( $_266 === \false) { $_268 = \false; break; }
-			$_268 = \true; break;
+			if( $_271 === \false) { $_273 = \false; break; }
+			$_273 = \true; break;
 		}
 		while(0);
-		if( $_268 === \false) { $_275 = \false; break; }
+		if( $_273 === \false) { $_280 = \false; break; }
 		if (\substr($this->string,$this->pos,1) === '(') {
 			$this->pos += 1;
 			$result["text"] .= '(';
 		}
-		else { $_275 = \false; break; }
+		else { $_280 = \false; break; }
 		$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) { $this->store( $result, $subres ); }
-		else { $_275 = \false; break; }
-		$res_272 = $result;
-		$pos_272 = $this->pos;
+		else { $_280 = \false; break; }
+		$res_277 = $result;
+		$pos_277 = $this->pos;
 		$matcher = 'match_'.'ArgumentList'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) {
 			$this->store( $result, $subres, "args" );
 		}
 		else {
-			$result = $res_272;
-			$this->pos = $pos_272;
-			unset( $res_272 );
-			unset( $pos_272 );
+			$result = $res_277;
+			$this->pos = $pos_277;
+			unset( $res_277 );
+			unset( $pos_277 );
 		}
 		$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) { $this->store( $result, $subres ); }
-		else { $_275 = \false; break; }
+		else { $_280 = \false; break; }
 		if (\substr($this->string,$this->pos,1) === ')') {
 			$this->pos += 1;
 			$result["text"] .= ')';
 		}
-		else { $_275 = \false; break; }
-		$_275 = \true; break;
+		else { $_280 = \false; break; }
+		$_280 = \true; break;
 	}
 	while(0);
-	if( $_275 === \true ) { return $this->finalise($result); }
-	if( $_275 === \false) { return \false; }
+	if( $_280 === \true ) { return $this->finalise($result); }
+	if( $_280 === \false) { return \false; }
 }
 
 
@@ -1572,54 +1602,54 @@ function match_FunctionCall ($stack = []) {
 protected $match_ArgumentList_typestack = array('ArgumentList');
 function match_ArgumentList ($stack = []) {
 	$matchrule = "ArgumentList"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_284 = \null;
+	$_289 = \null;
 	do {
 		$matcher = 'match_'.'Expression'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) {
 			$this->store( $result, $subres, "args" );
 		}
-		else { $_284 = \false; break; }
+		else { $_289 = \false; break; }
 		while (\true) {
-			$res_283 = $result;
-			$pos_283 = $this->pos;
-			$_282 = \null;
+			$res_288 = $result;
+			$pos_288 = $this->pos;
+			$_287 = \null;
 			do {
 				$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 				if ($subres !== \false) { $this->store( $result, $subres ); }
-				else { $_282 = \false; break; }
+				else { $_287 = \false; break; }
 				if (\substr($this->string,$this->pos,1) === ',') {
 					$this->pos += 1;
 					$result["text"] .= ',';
 				}
-				else { $_282 = \false; break; }
+				else { $_287 = \false; break; }
 				$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 				if ($subres !== \false) { $this->store( $result, $subres ); }
-				else { $_282 = \false; break; }
+				else { $_287 = \false; break; }
 				$matcher = 'match_'.'Expression'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 				if ($subres !== \false) {
 					$this->store( $result, $subres, "args" );
 				}
-				else { $_282 = \false; break; }
-				$_282 = \true; break;
+				else { $_287 = \false; break; }
+				$_287 = \true; break;
 			}
 			while(0);
-			if( $_282 === \false) {
-				$result = $res_283;
-				$this->pos = $pos_283;
-				unset( $res_283 );
-				unset( $pos_283 );
+			if( $_287 === \false) {
+				$result = $res_288;
+				$this->pos = $pos_288;
+				unset( $res_288 );
+				unset( $pos_288 );
 				break;
 			}
 		}
-		$_284 = \true; break;
+		$_289 = \true; break;
 	}
 	while(0);
-	if( $_284 === \true ) { return $this->finalise($result); }
-	if( $_284 === \false) { return \false; }
+	if( $_289 === \true ) { return $this->finalise($result); }
+	if( $_289 === \false) { return \false; }
 }
 
 
@@ -1627,54 +1657,54 @@ function match_ArgumentList ($stack = []) {
 protected $match_FunctionDefinitionArgumentList_typestack = array('FunctionDefinitionArgumentList');
 function match_FunctionDefinitionArgumentList ($stack = []) {
 	$matchrule = "FunctionDefinitionArgumentList"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_293 = \null;
+	$_298 = \null;
 	do {
 		$matcher = 'match_'.'VariableName'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) {
 			$this->store( $result, $subres, "skip" );
 		}
-		else { $_293 = \false; break; }
+		else { $_298 = \false; break; }
 		while (\true) {
-			$res_292 = $result;
-			$pos_292 = $this->pos;
-			$_291 = \null;
+			$res_297 = $result;
+			$pos_297 = $this->pos;
+			$_296 = \null;
 			do {
 				$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 				if ($subres !== \false) { $this->store( $result, $subres ); }
-				else { $_291 = \false; break; }
+				else { $_296 = \false; break; }
 				if (\substr($this->string,$this->pos,1) === ',') {
 					$this->pos += 1;
 					$result["text"] .= ',';
 				}
-				else { $_291 = \false; break; }
+				else { $_296 = \false; break; }
 				$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 				if ($subres !== \false) { $this->store( $result, $subres ); }
-				else { $_291 = \false; break; }
+				else { $_296 = \false; break; }
 				$matcher = 'match_'.'VariableName'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 				if ($subres !== \false) {
 					$this->store( $result, $subres, "skip" );
 				}
-				else { $_291 = \false; break; }
-				$_291 = \true; break;
+				else { $_296 = \false; break; }
+				$_296 = \true; break;
 			}
 			while(0);
-			if( $_291 === \false) {
-				$result = $res_292;
-				$this->pos = $pos_292;
-				unset( $res_292 );
-				unset( $pos_292 );
+			if( $_296 === \false) {
+				$result = $res_297;
+				$this->pos = $pos_297;
+				unset( $res_297 );
+				unset( $pos_297 );
 				break;
 			}
 		}
-		$_293 = \true; break;
+		$_298 = \true; break;
 	}
 	while(0);
-	if( $_293 === \true ) { return $this->finalise($result); }
-	if( $_293 === \false) { return \false; }
+	if( $_298 === \true ) { return $this->finalise($result); }
+	if( $_298 === \false) { return \false; }
 }
 
 
@@ -1682,68 +1712,68 @@ function match_FunctionDefinitionArgumentList ($stack = []) {
 protected $match_FunctionDefinition_typestack = array('FunctionDefinition');
 function match_FunctionDefinition ($stack = []) {
 	$matchrule = "FunctionDefinition"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_306 = \null;
+	$_311 = \null;
 	do {
 		if (( $subres = $this->literal( 'function' ) ) !== \false) { $result["text"] .= $subres; }
-		else { $_306 = \false; break; }
+		else { $_311 = \false; break; }
 		if (( $subres = $this->whitespace(  ) ) !== \false) { $result["text"] .= $subres; }
-		else { $_306 = \false; break; }
+		else { $_311 = \false; break; }
 		$matcher = 'match_'.'VariableName'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) {
 			$this->store( $result, $subres, "function" );
 		}
-		else { $_306 = \false; break; }
+		else { $_311 = \false; break; }
 		$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) { $this->store( $result, $subres ); }
-		else { $_306 = \false; break; }
+		else { $_311 = \false; break; }
 		if (\substr($this->string,$this->pos,1) === '(') {
 			$this->pos += 1;
 			$result["text"] .= '(';
 		}
-		else { $_306 = \false; break; }
+		else { $_311 = \false; break; }
 		$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) { $this->store( $result, $subres ); }
-		else { $_306 = \false; break; }
-		$res_301 = $result;
-		$pos_301 = $this->pos;
+		else { $_311 = \false; break; }
+		$res_306 = $result;
+		$pos_306 = $this->pos;
 		$matcher = 'match_'.'FunctionDefinitionArgumentList'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) {
 			$this->store( $result, $subres, "args" );
 		}
 		else {
-			$result = $res_301;
-			$this->pos = $pos_301;
-			unset( $res_301 );
-			unset( $pos_301 );
+			$result = $res_306;
+			$this->pos = $pos_306;
+			unset( $res_306 );
+			unset( $pos_306 );
 		}
 		$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) { $this->store( $result, $subres ); }
-		else { $_306 = \false; break; }
+		else { $_311 = \false; break; }
 		if (\substr($this->string,$this->pos,1) === ')') {
 			$this->pos += 1;
 			$result["text"] .= ')';
 		}
-		else { $_306 = \false; break; }
+		else { $_311 = \false; break; }
 		$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) { $this->store( $result, $subres ); }
-		else { $_306 = \false; break; }
+		else { $_311 = \false; break; }
 		$matcher = 'match_'.'Block'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) {
 			$this->store( $result, $subres, "body" );
 		}
-		else { $_306 = \false; break; }
-		$_306 = \true; break;
+		else { $_311 = \false; break; }
+		$_311 = \true; break;
 	}
 	while(0);
-	if( $_306 === \true ) { return $this->finalise($result); }
-	if( $_306 === \false) { return \false; }
+	if( $_311 === \true ) { return $this->finalise($result); }
+	if( $_311 === \false) { return \false; }
 }
 
 
@@ -1751,59 +1781,59 @@ function match_FunctionDefinition ($stack = []) {
 protected $match_IfStatement_typestack = array('IfStatement');
 function match_IfStatement ($stack = []) {
 	$matchrule = "IfStatement"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_319 = \null;
+	$_324 = \null;
 	do {
 		if (( $subres = $this->literal( 'if' ) ) !== \false) { $result["text"] .= $subres; }
-		else { $_319 = \false; break; }
+		else { $_324 = \false; break; }
 		$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) { $this->store( $result, $subres ); }
-		else { $_319 = \false; break; }
+		else { $_324 = \false; break; }
 		if (\substr($this->string,$this->pos,1) === '(') {
 			$this->pos += 1;
 			$result["text"] .= '(';
 		}
-		else { $_319 = \false; break; }
+		else { $_324 = \false; break; }
 		$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) { $this->store( $result, $subres ); }
-		else { $_319 = \false; break; }
+		else { $_324 = \false; break; }
 		$matcher = 'match_'.'Expression'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) {
 			$this->store( $result, $subres, "left" );
 		}
-		else { $_319 = \false; break; }
+		else { $_324 = \false; break; }
 		$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) { $this->store( $result, $subres ); }
-		else { $_319 = \false; break; }
+		else { $_324 = \false; break; }
 		if (\substr($this->string,$this->pos,1) === ')') {
 			$this->pos += 1;
 			$result["text"] .= ')';
 		}
-		else { $_319 = \false; break; }
+		else { $_324 = \false; break; }
 		$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) { $this->store( $result, $subres ); }
-		else { $_319 = \false; break; }
-		$_317 = \null;
+		else { $_324 = \false; break; }
+		$_322 = \null;
 		do {
 			$matcher = 'match_'.'Block'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 			if ($subres !== \false) {
 				$this->store( $result, $subres, "right" );
 			}
-			else { $_317 = \false; break; }
-			$_317 = \true; break;
+			else { $_322 = \false; break; }
+			$_322 = \true; break;
 		}
 		while(0);
-		if( $_317 === \false) { $_319 = \false; break; }
-		$_319 = \true; break;
+		if( $_322 === \false) { $_324 = \false; break; }
+		$_324 = \true; break;
 	}
 	while(0);
-	if( $_319 === \true ) { return $this->finalise($result); }
-	if( $_319 === \false) { return \false; }
+	if( $_324 === \true ) { return $this->finalise($result); }
+	if( $_324 === \false) { return \false; }
 }
 
 
@@ -1811,59 +1841,59 @@ function match_IfStatement ($stack = []) {
 protected $match_WhileStatement_typestack = array('WhileStatement');
 function match_WhileStatement ($stack = []) {
 	$matchrule = "WhileStatement"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_332 = \null;
+	$_337 = \null;
 	do {
 		if (( $subres = $this->literal( 'while' ) ) !== \false) { $result["text"] .= $subres; }
-		else { $_332 = \false; break; }
+		else { $_337 = \false; break; }
 		$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) { $this->store( $result, $subres ); }
-		else { $_332 = \false; break; }
+		else { $_337 = \false; break; }
 		if (\substr($this->string,$this->pos,1) === '(') {
 			$this->pos += 1;
 			$result["text"] .= '(';
 		}
-		else { $_332 = \false; break; }
+		else { $_337 = \false; break; }
 		$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) { $this->store( $result, $subres ); }
-		else { $_332 = \false; break; }
+		else { $_337 = \false; break; }
 		$matcher = 'match_'.'Expression'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) {
 			$this->store( $result, $subres, "left" );
 		}
-		else { $_332 = \false; break; }
+		else { $_337 = \false; break; }
 		$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) { $this->store( $result, $subres ); }
-		else { $_332 = \false; break; }
+		else { $_337 = \false; break; }
 		if (\substr($this->string,$this->pos,1) === ')') {
 			$this->pos += 1;
 			$result["text"] .= ')';
 		}
-		else { $_332 = \false; break; }
+		else { $_337 = \false; break; }
 		$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) { $this->store( $result, $subres ); }
-		else { $_332 = \false; break; }
-		$_330 = \null;
+		else { $_337 = \false; break; }
+		$_335 = \null;
 		do {
 			$matcher = 'match_'.'Block'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 			if ($subres !== \false) {
 				$this->store( $result, $subres, "right" );
 			}
-			else { $_330 = \false; break; }
-			$_330 = \true; break;
+			else { $_335 = \false; break; }
+			$_335 = \true; break;
 		}
 		while(0);
-		if( $_330 === \false) { $_332 = \false; break; }
-		$_332 = \true; break;
+		if( $_335 === \false) { $_337 = \false; break; }
+		$_337 = \true; break;
 	}
 	while(0);
-	if( $_332 === \true ) { return $this->finalise($result); }
-	if( $_332 === \false) { return \false; }
+	if( $_337 === \true ) { return $this->finalise($result); }
+	if( $_337 === \false) { return \false; }
 }
 
 
@@ -1871,103 +1901,71 @@ function match_WhileStatement ($stack = []) {
 protected $match_ForeachStatement_typestack = array('ForeachStatement');
 function match_ForeachStatement ($stack = []) {
 	$matchrule = "ForeachStatement"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_349 = \null;
+	$_354 = \null;
 	do {
 		if (( $subres = $this->literal( 'foreach' ) ) !== \false) { $result["text"] .= $subres; }
-		else { $_349 = \false; break; }
+		else { $_354 = \false; break; }
 		$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) { $this->store( $result, $subres ); }
-		else { $_349 = \false; break; }
+		else { $_354 = \false; break; }
 		if (\substr($this->string,$this->pos,1) === '(') {
 			$this->pos += 1;
 			$result["text"] .= '(';
 		}
-		else { $_349 = \false; break; }
+		else { $_354 = \false; break; }
 		$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) { $this->store( $result, $subres ); }
-		else { $_349 = \false; break; }
+		else { $_354 = \false; break; }
 		$matcher = 'match_'.'Expression'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) {
 			$this->store( $result, $subres, "left" );
 		}
-		else { $_349 = \false; break; }
+		else { $_354 = \false; break; }
 		$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) { $this->store( $result, $subres ); }
-		else { $_349 = \false; break; }
+		else { $_354 = \false; break; }
 		if (( $subres = $this->literal( 'as' ) ) !== \false) { $result["text"] .= $subres; }
-		else { $_349 = \false; break; }
+		else { $_354 = \false; break; }
 		$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) { $this->store( $result, $subres ); }
-		else { $_349 = \false; break; }
+		else { $_354 = \false; break; }
 		$matcher = 'match_'.'VariableName'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) {
 			$this->store( $result, $subres, "item" );
 		}
-		else { $_349 = \false; break; }
+		else { $_354 = \false; break; }
 		$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) { $this->store( $result, $subres ); }
-		else { $_349 = \false; break; }
+		else { $_354 = \false; break; }
 		if (\substr($this->string,$this->pos,1) === ')') {
 			$this->pos += 1;
 			$result["text"] .= ')';
 		}
-		else { $_349 = \false; break; }
+		else { $_354 = \false; break; }
 		$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) { $this->store( $result, $subres ); }
-		else { $_349 = \false; break; }
-		$_347 = \null;
+		else { $_354 = \false; break; }
+		$_352 = \null;
 		do {
 			$matcher = 'match_'.'Block'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 			if ($subres !== \false) {
 				$this->store( $result, $subres, "right" );
 			}
-			else { $_347 = \false; break; }
-			$_347 = \true; break;
+			else { $_352 = \false; break; }
+			$_352 = \true; break;
 		}
 		while(0);
-		if( $_347 === \false) { $_349 = \false; break; }
-		$_349 = \true; break;
-	}
-	while(0);
-	if( $_349 === \true ) { return $this->finalise($result); }
-	if( $_349 === \false) { return \false; }
-}
-
-
-/* CommandStatements: skip:EchoStatement | skip:ReturnStatement */
-protected $match_CommandStatements_typestack = array('CommandStatements');
-function match_CommandStatements ($stack = []) {
-	$matchrule = "CommandStatements"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_354 = \null;
-	do {
-		$res_351 = $result;
-		$pos_351 = $this->pos;
-		$matcher = 'match_'.'EchoStatement'; $key = $matcher; $pos = $this->pos;
-		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
-		if ($subres !== \false) {
-			$this->store( $result, $subres, "skip" );
-			$_354 = \true; break;
-		}
-		$result = $res_351;
-		$this->pos = $pos_351;
-		$matcher = 'match_'.'ReturnStatement'; $key = $matcher; $pos = $this->pos;
-		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
-		if ($subres !== \false) {
-			$this->store( $result, $subres, "skip" );
-			$_354 = \true; break;
-		}
-		$result = $res_351;
-		$this->pos = $pos_351;
-		$_354 = \false; break;
+		if( $_352 === \false) { $_354 = \false; break; }
+		$_354 = \true; break;
 	}
 	while(0);
 	if( $_354 === \true ) { return $this->finalise($result); }
@@ -1975,23 +1973,31 @@ function match_CommandStatements ($stack = []) {
 }
 
 
-/* EchoStatement: "echo" [ subject:Expression */
-protected $match_EchoStatement_typestack = array('EchoStatement');
-function match_EchoStatement ($stack = []) {
-	$matchrule = "EchoStatement"; $result = $this->construct($matchrule, $matchrule, \null);
+/* CommandStatements: skip:EchoStatement | skip:ReturnStatement */
+protected $match_CommandStatements_typestack = array('CommandStatements');
+function match_CommandStatements ($stack = []) {
+	$matchrule = "CommandStatements"; $result = $this->construct($matchrule, $matchrule, \null);
 	$_359 = \null;
 	do {
-		if (( $subres = $this->literal( 'echo' ) ) !== \false) { $result["text"] .= $subres; }
-		else { $_359 = \false; break; }
-		if (( $subres = $this->whitespace(  ) ) !== \false) { $result["text"] .= $subres; }
-		else { $_359 = \false; break; }
-		$matcher = 'match_'.'Expression'; $key = $matcher; $pos = $this->pos;
+		$res_356 = $result;
+		$pos_356 = $this->pos;
+		$matcher = 'match_'.'EchoStatement'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) {
-			$this->store( $result, $subres, "subject" );
+			$this->store( $result, $subres, "skip" );
+			$_359 = \true; break;
 		}
-		else { $_359 = \false; break; }
-		$_359 = \true; break;
+		$result = $res_356;
+		$this->pos = $pos_356;
+		$matcher = 'match_'.'ReturnStatement'; $key = $matcher; $pos = $this->pos;
+		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
+		if ($subres !== \false) {
+			$this->store( $result, $subres, "skip" );
+			$_359 = \true; break;
+		}
+		$result = $res_356;
+		$this->pos = $pos_356;
+		$_359 = \false; break;
 	}
 	while(0);
 	if( $_359 === \true ) { return $this->finalise($result); }
@@ -1999,40 +2005,64 @@ function match_EchoStatement ($stack = []) {
 }
 
 
+/* EchoStatement: "echo" [ subject:Expression */
+protected $match_EchoStatement_typestack = array('EchoStatement');
+function match_EchoStatement ($stack = []) {
+	$matchrule = "EchoStatement"; $result = $this->construct($matchrule, $matchrule, \null);
+	$_364 = \null;
+	do {
+		if (( $subres = $this->literal( 'echo' ) ) !== \false) { $result["text"] .= $subres; }
+		else { $_364 = \false; break; }
+		if (( $subres = $this->whitespace(  ) ) !== \false) { $result["text"] .= $subres; }
+		else { $_364 = \false; break; }
+		$matcher = 'match_'.'Expression'; $key = $matcher; $pos = $this->pos;
+		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
+		if ($subres !== \false) {
+			$this->store( $result, $subres, "subject" );
+		}
+		else { $_364 = \false; break; }
+		$_364 = \true; break;
+	}
+	while(0);
+	if( $_364 === \true ) { return $this->finalise($result); }
+	if( $_364 === \false) { return \false; }
+}
+
+
 /* ReturnStatement: "return" ( [ subject:Expression )? */
 protected $match_ReturnStatement_typestack = array('ReturnStatement');
 function match_ReturnStatement ($stack = []) {
 	$matchrule = "ReturnStatement"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_366 = \null;
+	$_371 = \null;
 	do {
 		if (( $subres = $this->literal( 'return' ) ) !== \false) { $result["text"] .= $subres; }
-		else { $_366 = \false; break; }
-		$res_365 = $result;
-		$pos_365 = $this->pos;
-		$_364 = \null;
+		else { $_371 = \false; break; }
+		$res_370 = $result;
+		$pos_370 = $this->pos;
+		$_369 = \null;
 		do {
 			if (( $subres = $this->whitespace(  ) ) !== \false) { $result["text"] .= $subres; }
-			else { $_364 = \false; break; }
+			else { $_369 = \false; break; }
 			$matcher = 'match_'.'Expression'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 			if ($subres !== \false) {
 				$this->store( $result, $subres, "subject" );
 			}
-			else { $_364 = \false; break; }
-			$_364 = \true; break;
+			else { $_369 = \false; break; }
+			$_369 = \true; break;
 		}
 		while(0);
-		if( $_364 === \false) {
-			$result = $res_365;
-			$this->pos = $pos_365;
-			unset( $res_365 );
-			unset( $pos_365 );
+		if( $_369 === \false) {
+			$result = $res_370;
+			$this->pos = $pos_370;
+			unset( $res_370 );
+			unset( $pos_370 );
 		}
-		$_366 = \true; break;
+		$_371 = \true; break;
 	}
 	while(0);
-	if( $_366 === \true ) { return $this->finalise($result); }
-	if( $_366 === \false) { return \false; }
+	if( $_371 === \true ) { return $this->finalise($result); }
+	if( $_371 === \false) { return \false; }
 }
 
 
@@ -2040,91 +2070,91 @@ function match_ReturnStatement ($stack = []) {
 protected $match_BlockStatements_typestack = array('BlockStatements');
 function match_BlockStatements ($stack = []) {
 	$matchrule = "BlockStatements"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_384 = \null;
+	$_389 = \null;
 	do {
-		$res_368 = $result;
-		$pos_368 = $this->pos;
+		$res_373 = $result;
+		$pos_373 = $this->pos;
 		if (( $subres = $this->rx( '/[A-Za-z]/' ) ) !== \false) {
 			$result["text"] .= $subres;
-			$result = $res_368;
-			$this->pos = $pos_368;
+			$result = $res_373;
+			$this->pos = $pos_373;
 		}
 		else {
-			$result = $res_368;
-			$this->pos = $pos_368;
-			$_384 = \false; break;
+			$result = $res_373;
+			$this->pos = $pos_373;
+			$_389 = \false; break;
 		}
-		$_382 = \null;
+		$_387 = \null;
 		do {
-			$_380 = \null;
+			$_385 = \null;
 			do {
-				$res_369 = $result;
-				$pos_369 = $this->pos;
+				$res_374 = $result;
+				$pos_374 = $this->pos;
 				$matcher = 'match_'.'IfStatement'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 				if ($subres !== \false) {
 					$this->store( $result, $subres, "skip" );
-					$_380 = \true; break;
+					$_385 = \true; break;
 				}
-				$result = $res_369;
-				$this->pos = $pos_369;
-				$_378 = \null;
+				$result = $res_374;
+				$this->pos = $pos_374;
+				$_383 = \null;
 				do {
-					$res_371 = $result;
-					$pos_371 = $this->pos;
+					$res_376 = $result;
+					$pos_376 = $this->pos;
 					$matcher = 'match_'.'WhileStatement'; $key = $matcher; $pos = $this->pos;
 					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 					if ($subres !== \false) {
 						$this->store( $result, $subres, "skip" );
-						$_378 = \true; break;
+						$_383 = \true; break;
 					}
-					$result = $res_371;
-					$this->pos = $pos_371;
-					$_376 = \null;
+					$result = $res_376;
+					$this->pos = $pos_376;
+					$_381 = \null;
 					do {
-						$res_373 = $result;
-						$pos_373 = $this->pos;
+						$res_378 = $result;
+						$pos_378 = $this->pos;
 						$matcher = 'match_'.'ForeachStatement'; $key = $matcher; $pos = $this->pos;
 						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 						if ($subres !== \false) {
 							$this->store( $result, $subres, "skip" );
-							$_376 = \true; break;
+							$_381 = \true; break;
 						}
-						$result = $res_373;
-						$this->pos = $pos_373;
+						$result = $res_378;
+						$this->pos = $pos_378;
 						$matcher = 'match_'.'FunctionDefinition'; $key = $matcher; $pos = $this->pos;
 						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 						if ($subres !== \false) {
 							$this->store( $result, $subres, "skip" );
-							$_376 = \true; break;
+							$_381 = \true; break;
 						}
-						$result = $res_373;
-						$this->pos = $pos_373;
-						$_376 = \false; break;
+						$result = $res_378;
+						$this->pos = $pos_378;
+						$_381 = \false; break;
 					}
 					while(0);
-					if( $_376 === \true ) { $_378 = \true; break; }
-					$result = $res_371;
-					$this->pos = $pos_371;
-					$_378 = \false; break;
+					if( $_381 === \true ) { $_383 = \true; break; }
+					$result = $res_376;
+					$this->pos = $pos_376;
+					$_383 = \false; break;
 				}
 				while(0);
-				if( $_378 === \true ) { $_380 = \true; break; }
-				$result = $res_369;
-				$this->pos = $pos_369;
-				$_380 = \false; break;
+				if( $_383 === \true ) { $_385 = \true; break; }
+				$result = $res_374;
+				$this->pos = $pos_374;
+				$_385 = \false; break;
 			}
 			while(0);
-			if( $_380 === \false) { $_382 = \false; break; }
-			$_382 = \true; break;
+			if( $_385 === \false) { $_387 = \false; break; }
+			$_387 = \true; break;
 		}
 		while(0);
-		if( $_382 === \false) { $_384 = \false; break; }
-		$_384 = \true; break;
+		if( $_387 === \false) { $_389 = \false; break; }
+		$_389 = \true; break;
 	}
 	while(0);
-	if( $_384 === \true ) { return $this->finalise($result); }
-	if( $_384 === \false) { return \false; }
+	if( $_389 === \true ) { return $this->finalise($result); }
+	if( $_389 === \false) { return \false; }
 }
 
 
@@ -2132,73 +2162,73 @@ function match_BlockStatements ($stack = []) {
 protected $match_Statement_typestack = array('Statement');
 function match_Statement ($stack = []) {
 	$matchrule = "Statement"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_398 = \null;
+	$_403 = \null;
 	do {
-		$res_386 = $result;
-		$pos_386 = $this->pos;
+		$res_391 = $result;
+		$pos_391 = $this->pos;
 		if (( $subres = $this->rx( '/[\s\{\};]/' ) ) !== \false) {
 			$result["text"] .= $subres;
-			$result = $res_386;
-			$this->pos = $pos_386;
-			$_398 = \false; break;
+			$result = $res_391;
+			$this->pos = $pos_391;
+			$_403 = \false; break;
 		}
 		else {
-			$result = $res_386;
-			$this->pos = $pos_386;
+			$result = $res_391;
+			$this->pos = $pos_391;
 		}
-		$_396 = \null;
+		$_401 = \null;
 		do {
-			$_394 = \null;
+			$_399 = \null;
 			do {
-				$res_387 = $result;
-				$pos_387 = $this->pos;
+				$res_392 = $result;
+				$pos_392 = $this->pos;
 				$matcher = 'match_'.'BlockStatements'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 				if ($subres !== \false) {
 					$this->store( $result, $subres, "skip" );
-					$_394 = \true; break;
+					$_399 = \true; break;
 				}
-				$result = $res_387;
-				$this->pos = $pos_387;
-				$_392 = \null;
+				$result = $res_392;
+				$this->pos = $pos_392;
+				$_397 = \null;
 				do {
-					$res_389 = $result;
-					$pos_389 = $this->pos;
+					$res_394 = $result;
+					$pos_394 = $this->pos;
 					$matcher = 'match_'.'CommandStatements'; $key = $matcher; $pos = $this->pos;
 					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 					if ($subres !== \false) {
 						$this->store( $result, $subres, "skip" );
-						$_392 = \true; break;
+						$_397 = \true; break;
 					}
-					$result = $res_389;
-					$this->pos = $pos_389;
+					$result = $res_394;
+					$this->pos = $pos_394;
 					$matcher = 'match_'.'Expression'; $key = $matcher; $pos = $this->pos;
 					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 					if ($subres !== \false) {
 						$this->store( $result, $subres, "skip" );
-						$_392 = \true; break;
+						$_397 = \true; break;
 					}
-					$result = $res_389;
-					$this->pos = $pos_389;
-					$_392 = \false; break;
+					$result = $res_394;
+					$this->pos = $pos_394;
+					$_397 = \false; break;
 				}
 				while(0);
-				if( $_392 === \true ) { $_394 = \true; break; }
-				$result = $res_387;
-				$this->pos = $pos_387;
-				$_394 = \false; break;
+				if( $_397 === \true ) { $_399 = \true; break; }
+				$result = $res_392;
+				$this->pos = $pos_392;
+				$_399 = \false; break;
 			}
 			while(0);
-			if( $_394 === \false) { $_396 = \false; break; }
-			$_396 = \true; break;
+			if( $_399 === \false) { $_401 = \false; break; }
+			$_401 = \true; break;
 		}
 		while(0);
-		if( $_396 === \false) { $_398 = \false; break; }
-		$_398 = \true; break;
+		if( $_401 === \false) { $_403 = \false; break; }
+		$_403 = \true; break;
 	}
 	while(0);
-	if( $_398 === \true ) { return $this->finalise($result); }
-	if( $_398 === \false) { return \false; }
+	if( $_403 === \true ) { return $this->finalise($result); }
+	if( $_403 === \false) { return \false; }
 }
 
 
@@ -2206,46 +2236,46 @@ function match_Statement ($stack = []) {
 protected $match_Block_typestack = array('Block');
 function match_Block ($stack = []) {
 	$matchrule = "Block"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_406 = \null;
+	$_411 = \null;
 	do {
 		if (\substr($this->string,$this->pos,1) === '{') {
 			$this->pos += 1;
 			$result["text"] .= '{';
 		}
-		else { $_406 = \false; break; }
+		else { $_411 = \false; break; }
 		$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) { $this->store( $result, $subres ); }
-		else { $_406 = \false; break; }
-		$res_404 = $result;
-		$pos_404 = $this->pos;
-		$_403 = \null;
+		else { $_411 = \false; break; }
+		$res_409 = $result;
+		$pos_409 = $this->pos;
+		$_408 = \null;
 		do {
 			$matcher = 'match_'.'Program'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 			if ($subres !== \false) {
 				$this->store( $result, $subres, "skip" );
 			}
-			else { $_403 = \false; break; }
-			$_403 = \true; break;
+			else { $_408 = \false; break; }
+			$_408 = \true; break;
 		}
 		while(0);
-		if( $_403 === \false) {
-			$result = $res_404;
-			$this->pos = $pos_404;
-			unset( $res_404 );
-			unset( $pos_404 );
+		if( $_408 === \false) {
+			$result = $res_409;
+			$this->pos = $pos_409;
+			unset( $res_409 );
+			unset( $pos_409 );
 		}
 		if (\substr($this->string,$this->pos,1) === '}') {
 			$this->pos += 1;
 			$result["text"] .= '}';
 		}
-		else { $_406 = \false; break; }
-		$_406 = \true; break;
+		else { $_411 = \false; break; }
+		$_411 = \true; break;
 	}
 	while(0);
-	if( $_406 === \true ) { return $this->finalise($result); }
-	if( $_406 === \false) { return \false; }
+	if( $_411 === \true ) { return $this->finalise($result); }
+	if( $_411 === \false) { return \false; }
 }
 
 
@@ -2277,30 +2307,30 @@ function match_NL ($stack = []) {
 protected $match_SEP_typestack = array('SEP');
 function match_SEP ($stack = []) {
 	$matchrule = "SEP"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_413 = \null;
+	$_418 = \null;
 	do {
-		$res_410 = $result;
-		$pos_410 = $this->pos;
+		$res_415 = $result;
+		$pos_415 = $this->pos;
 		if (\substr($this->string,$this->pos,1) === ';') {
 			$this->pos += 1;
 			$result["text"] .= ';';
-			$_413 = \true; break;
+			$_418 = \true; break;
 		}
-		$result = $res_410;
-		$this->pos = $pos_410;
+		$result = $res_415;
+		$this->pos = $pos_415;
 		$matcher = 'match_'.'NL'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) {
 			$this->store( $result, $subres );
-			$_413 = \true; break;
+			$_418 = \true; break;
 		}
-		$result = $res_410;
-		$this->pos = $pos_410;
-		$_413 = \false; break;
+		$result = $res_415;
+		$this->pos = $pos_415;
+		$_418 = \false; break;
 	}
 	while(0);
-	if( $_413 === \true ) { return $this->finalise($result); }
-	if( $_413 === \false) { return \false; }
+	if( $_418 === \true ) { return $this->finalise($result); }
+	if( $_418 === \false) { return \false; }
 }
 
 
@@ -2308,69 +2338,69 @@ function match_SEP ($stack = []) {
 protected $match_Program_typestack = array('Program');
 function match_Program ($stack = []) {
 	$matchrule = "Program"; $result = $this->construct($matchrule, $matchrule, \null);
-	$_423 = \null;
+	$_428 = \null;
 	do {
 		$count = 0;
 		while (\true) {
-			$res_421 = $result;
-			$pos_421 = $this->pos;
-			$_420 = \null;
+			$res_426 = $result;
+			$pos_426 = $this->pos;
+			$_425 = \null;
 			do {
-				$res_415 = $result;
-				$pos_415 = $this->pos;
+				$res_420 = $result;
+				$pos_420 = $this->pos;
 				if (( $subres = $this->rx( '/$/' ) ) !== \false) {
 					$result["text"] .= $subres;
-					$result = $res_415;
-					$this->pos = $pos_415;
-					$_420 = \false; break;
+					$result = $res_420;
+					$this->pos = $pos_420;
+					$_425 = \false; break;
 				}
 				else {
-					$result = $res_415;
-					$this->pos = $pos_415;
+					$result = $res_420;
+					$this->pos = $pos_420;
 				}
 				$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 				if ($subres !== \false) { $this->store( $result, $subres ); }
-				else { $_420 = \false; break; }
-				$res_417 = $result;
-				$pos_417 = $this->pos;
+				else { $_425 = \false; break; }
+				$res_422 = $result;
+				$pos_422 = $this->pos;
 				$matcher = 'match_'.'Statement'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 				if ($subres !== \false) { $this->store( $result, $subres ); }
 				else {
-					$result = $res_417;
-					$this->pos = $pos_417;
-					unset( $res_417 );
-					unset( $pos_417 );
+					$result = $res_422;
+					$this->pos = $pos_422;
+					unset( $res_422 );
+					unset( $pos_422 );
 				}
 				if (( $subres = $this->whitespace(  ) ) !== \false) { $result["text"] .= $subres; }
 				$matcher = 'match_'.'SEP'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 				if ($subres !== \false) { $this->store( $result, $subres ); }
-				else { $_420 = \false; break; }
-				$_420 = \true; break;
+				else { $_425 = \false; break; }
+				$_425 = \true; break;
 			}
 			while(0);
-			if( $_420 === \false) {
-				$result = $res_421;
-				$this->pos = $pos_421;
-				unset( $res_421 );
-				unset( $pos_421 );
+			if( $_425 === \false) {
+				$result = $res_426;
+				$this->pos = $pos_426;
+				unset( $res_426 );
+				unset( $pos_426 );
 				break;
 			}
 			$count++;
 		}
 		if ($count >= 1) {  }
-		else { $_423 = \false; break; }
+		else { $_428 = \false; break; }
 		$matcher = 'match_'.'__'; $key = $matcher; $pos = $this->pos;
 		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );
 		if ($subres !== \false) { $this->store( $result, $subres ); }
-		else { $_423 = \false; break; }
-		$_423 = \true; break;
+		else { $_428 = \false; break; }
+		$_428 = \true; break;
 	}
 	while(0);
-	if( $_423 === \true ) { return $this->finalise($result); }
-	if( $_423 === \false) { return \false; }
+	if( $_428 === \true ) { return $this->finalise($result); }
+	if( $_428 === \false) { return \false; }
 }
 
 

--- a/src/parser/Grammar.peg
+++ b/src/parser/Grammar.peg
@@ -24,9 +24,10 @@ class CompiledParser extends Parser\Packrat {
 StringLiteral: / (?:".*?(?<!\\)")|(?:'.*?(?<!\\)') /s
 NumberLiteral: /-?\d+(\.\d+)?/
 BoolLiteral: "true" | "false"
+NullLiteral: "null"
 RegexLiteral: "/" /(\\\/|[^\/])+/ "/"
 
-Literal: skip:NumberLiteral | skip:StringLiteral | skip:BoolLiteral | skip:RegexLiteral
+Literal: skip:NumberLiteral | skip:StringLiteral | skip:BoolLiteral | skip:NullLiteral | skip:RegexLiteral
 VariableName: / ([a-zA-Z_][a-zA-Z0-9_]*) /
 Variable: ( core:VariableName post:UnaryOperator? ) | ( pre:UnaryOperator? core:VariableName )
 PropertyGetter: core:VariableName

--- a/src/structures/FunctionContainer.php
+++ b/src/structures/FunctionContainer.php
@@ -3,6 +3,7 @@
 namespace Smuuf\Primi\Structures;
 
 use \Smuuf\Primi\ReturnException;
+use \Smuuf\Primi\Structures\NullValue;
 use \Smuuf\Primi\Context;
 use \Smuuf\Primi\HandlerFactory;
 
@@ -56,6 +57,9 @@ class FunctionContainer extends \Smuuf\Primi\StrictObject {
 			} catch (ReturnException $e) {
 				return $e->getValue();
 			}
+
+			// Return null if no "return" was present.
+			return new NullValue;
 
 		};
 

--- a/src/structures/NullValue.php
+++ b/src/structures/NullValue.php
@@ -3,23 +3,22 @@
 namespace Smuuf\Primi\Structures;
 
 use \Smuuf\Primi\ISupportsComparison;
-use \Smuuf\Primi\Structures\NullValue;
+use \Smuuf\Primi\Structures\BoolValue;
+use \Smuuf\Primi\Structures\Value;
 
-class BoolValue extends Value implements ISupportsComparison {
+class NullValue extends Value implements ISupportsComparison {
 
-	const TYPE = "bool";
+	const TYPE = "null";
 
-	public function __construct(bool $value) {
-		$this->value = $value;
-	}
+	protected $value = null;
 
 	public function getStringValue(): string {
-		return $this->value ? 'true' : 'false';
+		return "null";
 	}
 
 	public function doComparison(string $op, Value $rightOperand): BoolValue {
 
-		self::allowTypes($rightOperand, self::class, NullValue::class);
+		self::allowTypes($rightOperand, self::class, BoolValue::class);
 
 		switch ($op) {
 			case "==":

--- a/src/structures/NumberValue.php
+++ b/src/structures/NumberValue.php
@@ -31,8 +31,8 @@ class NumberValue extends Value implements
 	public static function isNumericInt(string $input) {
 
 		// Trim any present sign, because it screws up the detection.
-		// "+1" _is_ int, but the equation below would wrongly return false, because
-		// it's casted to (int) and the sign disappears there -> false.
+		// "+1" _is_ int, but the equation below would wrongly return false,
+		// because it's casted to (int) and the sign disappears there -> false.
 		$input = \ltrim($input, "+-");
 
 		return (string) (int) $input === (string) $input;

--- a/src/structures/Value.php
+++ b/src/structures/Value.php
@@ -13,7 +13,7 @@ abstract class Value extends ValueFriends {
 
 		switch (true) {
 			case $value === null:
-				return new NullValue(false);
+				return new NullValue;
 			case \is_bool($value):
 				return new BoolValue($value);
 			case \is_array($value):

--- a/src/structures/Value.php
+++ b/src/structures/Value.php
@@ -12,6 +12,8 @@ abstract class Value extends ValueFriends {
 	public static function buildAutomatic($value) {
 
 		switch (true) {
+			case $value === null:
+				return new NullValue(false);
 			case \is_bool($value):
 				return new BoolValue($value);
 			case \is_array($value):

--- a/tests/language/suites/structures/variables.expect
+++ b/tests/language/suites/structures/variables.expect
@@ -8,3 +8,4 @@ g:StringValue:"xyz"
 i:StringValue:"this is some whole very long sentence."
 j:BoolValue:true
 k:BoolValue:false
+l:NullValue:null

--- a/tests/language/suites/structures/variables.primi
+++ b/tests/language/suites/structures/variables.primi
@@ -13,3 +13,6 @@ i = "this is some whole very long sentence.";
 // Bool
 j = true;
 k = false;
+
+// Null
+l = null;

--- a/tests/unit/value.null.phpt
+++ b/tests/unit/value.null.phpt
@@ -1,0 +1,47 @@
+<?php
+
+use \Tester\Assert;
+
+use \Smuuf\Primi\InternalArgumentCountException;
+use \Smuuf\Primi\Structures\{
+	BoolValue,
+	NullValue,
+	Value
+};
+
+require __DIR__ . '/../bootstrap.php';
+
+function get_val(Value $v) {
+	return $v->getInternalValue();
+}
+
+$null = new NullValue;
+$nullTwo = new NullValue;
+$true = new BoolValue(true);
+$false = new BoolValue(false);
+
+// Always null.
+
+Assert::same(null, get_val(new NullValue));
+Assert::same(null, get_val(new NullValue(1)));
+Assert::same(null, get_val(new NullValue("2")));
+Assert::same(null, get_val(new NullValue("hey")));
+Assert::same(null, get_val(new NullValue("")));
+Assert::same(null, get_val(new NullValue(1e6)));
+Assert::same(null, get_val(new NullValue(true)));
+Assert::same(null, get_val(new NullValue(false)));
+Assert::same(null, get_val(new NullValue(null)));
+
+//
+// Comparison.
+//
+
+// Equality.
+Assert::same(true, get_val($null->doComparison("==", $nullTwo)));
+Assert::same(true, get_val($null->doComparison("==", $false)));
+Assert::same(false, get_val($null->doComparison("==", $true)));
+
+// Inequality.
+Assert::same(false, get_val($null->doComparison("!=", $nullTwo)));
+Assert::same(false, get_val($null->doComparison("!=", $false)));
+Assert::same(true, get_val($null->doComparison("!=", $true)));


### PR DESCRIPTION
Introducing new `null` value. It's a new type and `null` is its only possible value.

Functions now return `null` by default, if no `return` is present. Furthermore, `return;` with no value now returns `null`, too *(it was causing an error until now.)*